### PR TITLE
Added missing call to MimeMessage.saveChanges

### DIFF
--- a/src/main/java/org/masukomi/aspirin/core/delivery/SendMessage.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/SendMessage.java
@@ -58,6 +58,7 @@ public class SendMessage implements DeliveryHandler {
 					transport = session.getTransport(outgoingMailServer);
 					try {
 						transport.connect();
+						message.saveChanges();
 						transport.sendMessage(message, addr);
 						if( transport instanceof SMTPTransport )
 						{


### PR DESCRIPTION
According to JavaDoc
http://docs.oracle.com/javaee/6/api/javax/mail/Transport.html#sendMessage:

"Unlike the static send method, the sendMessage method does not call the
saveChanges method on the message; the caller should do so. "

The call to saveChanges was missing here. The user of Aspirin cannot
know that this call is necessary and therefore it is necessary to make
the call here.
