### PR TITLE
Java 1.8 target, code style changes and nullability annotation support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
                 <!-- set to 1.6 to work around eclipse wining about @Override annotation on methods implementing interfaces -->
                 <configuration>
                     <encoding>utf8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -176,6 +176,12 @@
         	<groupId>org.slf4j</groupId>
         	<artifactId>slf4j-api</artifactId>
         	<version>1.6.1</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>20.0.0</version>
         </dependency>
 
         <!-- test -->

--- a/src/main/java/org/masukomi/aspirin/Aspirin.java
+++ b/src/main/java/org/masukomi/aspirin/Aspirin.java
@@ -1,10 +1,6 @@
 package org.masukomi.aspirin;
 
-import java.util.Date;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
-
+import org.jetbrains.annotations.NotNull;
 import org.masukomi.aspirin.core.AspirinInternal;
 import org.masukomi.aspirin.core.config.Configuration;
 import org.masukomi.aspirin.core.listener.AspirinListener;
@@ -14,134 +10,146 @@ import org.masukomi.aspirin.core.store.mail.SimpleMailStore;
 import org.masukomi.aspirin.core.store.queue.QueueInfo;
 import org.masukomi.aspirin.core.store.queue.QueueStore;
 
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.util.Date;
+import java.util.Objects;
+
 /**
- * This is the facade class of the Aspirin package. You should to use this 
+ * This is the facade class of the Aspirin package. You should to use this
  * class to manage email sending.
- * 
- * <h2>How it works?</h2>
- * 
- * <p>All email is represented by two main object:</p>
- * 
- * <p>A {@link MimeMessage}, which contains the RAW content of an email, so it 
- * could be very large. It is stored in a {@link MailStore} (there is two 
- * different implementation in Aspirin - one for simple in-memory usage
- * {@link SimpleMailStore} and one for heavy usage {@link FileMailStore}, this 
- * stores all MimeMessage objects on filesystem.) If no one of these default 
- * stores is good for you, you can implement the MailStore interface.</p>
- * 
- * <p>A QueueInfo {@link QueueInfo}, which represents an email and a 
- * recipient together, so one email could associated to more QueueInfo objects. 
- * This is an inside object, which contains all control informations of a mail 
- * item. In Aspirin package there is a {@link QueueStore} for in-memory use 
- * {@link org.masukomi.aspirin.core.store.queue.SimpleQueueStore}, this is the default implementation to store
- * QueueInfo objects. You can find an additional package, which use SQLite 
- * (based on <a href="http://sqljet.com">SQLJet</a>) to store QueueInfo 
- * object.</p>
- * 
- * <p><b>Hint:</b> If you need a Quality-of-Service mail sending, use
- * {@link FileMailStore} and additional <b>SqliteQueueStore</b>, they could 
- * preserve emails in queue between runs or on Java failure.</p>
- * 
- * @author Laszlo Solova
  *
+ * <h2>How it works?</h2>
+ *
+ * <p>All email is represented by two main object:</p>
+ *
+ * <p>A {@link MimeMessage}, which contains the RAW content of an email, so it
+ * could be very large. It is stored in a {@link MailStore} (there is two
+ * different implementation in Aspirin - one for simple in-memory usage
+ * {@link SimpleMailStore} and one for heavy usage {@link FileMailStore}, this
+ * stores all MimeMessage objects on filesystem.) If no one of these default
+ * stores is good for you, you can implement the MailStore interface.</p>
+ *
+ * <p>A QueueInfo {@link QueueInfo}, which represents an email and a
+ * recipient together, so one email could associated to more QueueInfo objects.
+ * This is an inside object, which contains all control informations of a mail
+ * item. In Aspirin package there is a {@link QueueStore} for in-memory use
+ * {@link org.masukomi.aspirin.core.store.queue.SimpleQueueStore}, this is the default implementation to store
+ * QueueInfo objects. You can find an additional package, which use SQLite
+ * (based on <a href="http://sqljet.com">SQLJet</a>) to store QueueInfo
+ * object.</p>
+ *
+ * <p><b>Hint:</b> If you need a Quality-of-Service mail sending, use
+ * {@link FileMailStore} and additional <b>SqliteQueueStore</b>, they could
+ * preserve emails in queue between runs or on Java failure.</p>
+ *
+ * @author Laszlo Solova
  */
 public class Aspirin {
-	
-	/**
-	 * Name of ID header placed in MimeMessage object. If no such header is 
-	 * defined in a MimeMessage, then MimeMessage's toString() method is used 
-	 * to generate a new one.
-	 */
-	public static final String HEADER_MAIL_ID = "X-Aspirin-MailID";
-	
-	/**
-	 * Name of expiration time header placed in MimeMessage object. Default 
-	 * expiration time is -1, unlimited. Expiration time is an epoch timestamp 
-	 * in milliseconds.
-	 */
-	public static final String HEADER_EXPIRY = "X-Aspirin-Expiry";
-	
-	/**
-	 * Add MimeMessage to deliver it.
-	 * @param msg MimeMessage to deliver.
-	 * @throws MessagingException If delivery add failed.
-	 */
-	public static void add(MimeMessage msg) throws MessagingException {
-		AspirinInternal.add(msg,-1);
-	}
-	
-	/**
-	 * Add MimeMessage to delivery.
-	 * @param msg MimeMessage
-	 * @param expiry Expiration of this email in milliseconds from now.
-	 * @throws MessagingException If delivery add failed.
-	 */
-	public static void add(MimeMessage msg, long expiry) throws MessagingException {
-		AspirinInternal.add(msg, expiry);
-	}
-	
-	/**
-	 * Add mail delivery status listener.
-	 * @param listener AspirinListener object
-	 */
-	public static void addListener(AspirinListener listener) {
-		AspirinInternal.addListener(listener);
-	}
-	
-	/**
-	 * It creates a new MimeMessage with standard Aspirin ID header.
-	 * 
-	 * @return new MimeMessage object
-	 * 
-	 */
-	public static MimeMessage createNewMimeMessage() {
-		return AspirinInternal.createNewMimeMessage();
-	}
-	
-	/**
-	 * Format expiry header content.
-	 * @param date Expiry date of a message.
-	 * @return Formatted date of expiry - as String. It could be add as 
-	 * MimeMessage header. Please use HEADER_EXPIRY constant as header name.
-	 */
-	public static String formatExpiry(Date date) {
-		return AspirinInternal.formatExpiry(date);
-	}
-	
-	/**
-	 * You can get configuration object, which could be changed to set up new 
-	 * values. Please use this method to set up your Aspirin instance. Of 
-	 * course default values are enough to simple mail sending.
-	 * 
-	 * @return Configuration object of Aspirin
-	 */
-	public static Configuration getConfiguration() {
-		return AspirinInternal.getConfiguration();
-	}
-	
-	/**
-	 * Remove an email from delivery.
-	 * @param mailid Unique Aspirin ID of this email.
-	 * @throws MessagingException If removing failed.
-	 */
-	public static void remove(String mailid) throws MessagingException {
-		AspirinInternal.remove(mailid);
-	}
-	
-	/**
-	 * Remove delivery status listener.
-	 * @param listener AspirinListener
-	 */
-	public static void removeListener(AspirinListener listener) {
-		AspirinInternal.removeListener(listener);
-	}
-	
-	/**
-	 * Call on shutting down your system. All aspirin processes will be 
-	 * shutdown as recommended.
-	 */
-	public static void shutdown() {
-		AspirinInternal.shutdown();
-	}
+    /**
+     * Name of ID header placed in MimeMessage object. If no such header is
+     * defined in a MimeMessage, then MimeMessage's toString() method is used
+     * to generate a new one.
+     */
+    @NotNull
+    public static final String HEADER_MAIL_ID = "X-Aspirin-MailID";
 
+    /**
+     * Name of expiration time header placed in MimeMessage object. Default
+     * expiration time is -1, unlimited. Expiration time is an epoch timestamp
+     * in milliseconds.
+     */
+    @NotNull
+    public static final String HEADER_EXPIRY = "X-Aspirin-Expiry";
+
+    /**
+     * Add MimeMessage to deliver it.
+     *
+     * @param msg MimeMessage to deliver.
+     * @throws MessagingException If delivery add failed.
+     */
+    public static void add(@NotNull MimeMessage msg) throws MessagingException {
+        AspirinInternal.add(Objects.requireNonNull(msg, "msg"), -1L);
+    }
+
+    /**
+     * Add MimeMessage to delivery.
+     *
+     * @param msg    MimeMessage
+     * @param expiry Expiration of this email in milliseconds from now.
+     * @throws MessagingException If delivery add failed.
+     */
+    public static void add(@NotNull MimeMessage msg, long expiry) throws MessagingException {
+        AspirinInternal.add(Objects.requireNonNull(msg, "msg"), expiry);
+    }
+
+    /**
+     * Add mail delivery status listener.
+     *
+     * @param listener AspirinListener object
+     */
+    public static void addListener(@NotNull AspirinListener listener) {
+        AspirinInternal.addListener(Objects.requireNonNull(listener, "listener"));
+    }
+
+    /**
+     * It creates a new MimeMessage with standard Aspirin ID header.
+     *
+     * @return new MimeMessage object
+     */
+    @NotNull
+    public static MimeMessage createNewMimeMessage() {
+        return AspirinInternal.createNewMimeMessage();
+    }
+
+    /**
+     * Format expiry header content.
+     *
+     * @param date Expiry date of a message.
+     * @return Formatted date of expiry - as String. It could be add as
+     * MimeMessage header. Please use HEADER_EXPIRY constant as header name.
+     */
+    @NotNull
+    public static String formatExpiry(@NotNull Date date) {
+        Objects.requireNonNull(date, "date");
+        return AspirinInternal.formatExpiry(date);
+    }
+
+    /**
+     * You can get configuration object, which could be changed to set up new
+     * values. Please use this method to set up your Aspirin instance. Of
+     * course default values are enough to simple mail sending.
+     *
+     * @return Configuration object of Aspirin
+     */
+    @NotNull
+    public static Configuration getConfiguration() {
+        return AspirinInternal.getConfiguration();
+    }
+
+    /**
+     * Remove an email from delivery.
+     *
+     * @param mailid Unique Aspirin ID of this email.
+     */
+    public static void remove(@NotNull String mailid) {
+        AspirinInternal.remove(Objects.requireNonNull(mailid, "mailid"));
+    }
+
+    /**
+     * Remove delivery status listener.
+     *
+     * @param listener AspirinListener
+     */
+    public static void removeListener(@NotNull AspirinListener listener) {
+        AspirinInternal.removeListener(Objects.requireNonNull(listener, "listener"));
+    }
+
+    /**
+     * Call on shutting down your system. All aspirin processes will be
+     * shutdown as recommended.
+     */
+    public static void shutdown() {
+        AspirinInternal.shutdown();
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/AspirinInternal.java
+++ b/src/main/java/org/masukomi/aspirin/core/AspirinInternal.java
@@ -58,7 +58,7 @@ public class AspirinInternal {
     /**
      * This counter is used to generate unique message ids.
      */
-    private static Integer idCounter = 0;
+    private static int idCounter;
 
     /**
      * You can get configuration object, which could be changed to set up new
@@ -143,15 +143,18 @@ public class AspirinInternal {
             defaultSession.set(Session.getDefaultInstance(System.getProperties()));
 
         MimeMessage mMesg = new MimeMessage(defaultSession.get());
+
         synchronized (idCounterLock) {
             long nowTime = System.currentTimeMillis() / 1000L;
             String newId = nowTime + "." + Integer.toHexString(idCounter++);
+
             try {
                 mMesg.setHeader(Aspirin.HEADER_MAIL_ID, newId);
             } catch (MessagingException msge) {
                 getLogger().warn("Aspirin Mail ID could not be generated.", msge);
             }
         }
+
         return mMesg;
     }
 
@@ -208,8 +211,7 @@ public class AspirinInternal {
 
         try {
             headers = message.getHeader(Aspirin.HEADER_MAIL_ID);
-            if (headers != null && 0 < headers.length)
-                return headers[0];
+            if (headers != null && 0 < headers.length) return headers[0];
         } catch (MessagingException e) {
             getLogger().error("MailID header could not be get from MimeMessage.", e);
         }
@@ -227,20 +229,20 @@ public class AspirinInternal {
         String[] headers;
         try {
             headers = message.getHeader(Aspirin.HEADER_EXPIRY);
-            if (headers != null && 0 < headers.length)
-                return expiryFormat.parse(headers[0]).getTime();
+            if (headers != null && 0 < headers.length) return expiryFormat.parse(headers[0]).getTime();
         } catch (ParseException | MessagingException e) {
             getLogger().error("Expiration header could not be get from MimeMessage.", e);
         }
-        if (configuration.getExpiry() == ConfigurationMBean.NEVER_EXPIRES)
-            return Long.MAX_VALUE;
+
+        if (configuration.getExpiry() == ConfigurationMBean.NEVER_EXPIRES) return Long.MAX_VALUE;
+
         try {
             Date sentDate = message.getReceivedDate();
-            if (sentDate != null)
-                return sentDate.getTime() + configuration.getExpiry();
+            if (sentDate != null) return sentDate.getTime() + configuration.getExpiry();
         } catch (MessagingException e) {
             getLogger().error("Expiration calculation could not be based on message date.", e);
         }
+
         return System.currentTimeMillis() + configuration.getExpiry();
     }
 
@@ -264,6 +266,7 @@ public class AspirinInternal {
         return deliveryManager;
     }
 
+    @NotNull
     public static ListenerManager getListenerManager() {
         return listenerManager.get();
     }
@@ -271,5 +274,4 @@ public class AspirinInternal {
     public static void shutdown() {
         deliveryManager.shutdown();
     }
-
 }

--- a/src/main/java/org/masukomi/aspirin/core/AspirinInternal.java
+++ b/src/main/java/org/masukomi/aspirin/core/AspirinInternal.java
@@ -1,243 +1,275 @@
 package org.masukomi.aspirin.core;
 
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-
-import javax.mail.Address;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMessage.RecipientType;
-
+import org.jetbrains.annotations.NotNull;
 import org.masukomi.aspirin.Aspirin;
 import org.masukomi.aspirin.core.config.Configuration;
+import org.masukomi.aspirin.core.config.ConfigurationMBean;
 import org.masukomi.aspirin.core.delivery.DeliveryManager;
 import org.masukomi.aspirin.core.listener.AspirinListener;
 import org.masukomi.aspirin.core.listener.ListenerManager;
 import org.slf4j.Logger;
 
+import javax.mail.*;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Inside factory and part provider class.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public class AspirinInternal {
-	
-	/**
-	 * Formatter to set expiry header. Please, use this formatter to create or 
-	 * change a current header.
-	 */
-	public static final SimpleDateFormat expiryFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
-	
-	/** This session is used to generate new MimeMessage objects. */
-	private static volatile Session defaultSession = null;
-	
-	/** This counter is used to generate unique message ids. */
-	private static Integer idCounter = 0;
-	private static Object idCounterLock = new Object();
-	
-	/** Configuration object of Aspirin. */
-	private static Configuration configuration = Configuration.getInstance();
-	/** AspirinListener management object. Create on first request. */
-	private static volatile ListenerManager listenerManager = null;
-	/** Delivery and QoS service management. Create on first request. */
-	private static volatile DeliveryManager deliveryManager = new DeliveryManager();
-	
-	/**
-	 * You can get configuration object, which could be changed to set up new 
-	 * values. Please use this method to set up your Aspirin instance. Of 
-	 * course default values are enough to simple mail sending.
-	 * 
-	 * @return Configuration object of Aspirin
-	 */
-	public static Configuration getConfiguration() {
-		return configuration;
-	}
-	
-	/**
-	 * Add MimeMessage to deliver it.
-	 * @param msg MimeMessage to deliver.
-	 * @throws MessagingException If delivery add failed.
-	 */
-	protected static void add(MimeMessage msg) throws MessagingException {
-		if( !deliveryManager.isAlive() )
-			deliveryManager.start();
-		deliveryManager.add(msg);
-	}
-	
-	/**
-	 * Add MimeMessage to delivery.
-	 * @param msg MimeMessage
-	 * @param expiry Expiration of this email in milliseconds from now.
-	 * @throws MessagingException If delivery add failed.
-	 */
-	public static void add(MimeMessage msg, long expiry) throws MessagingException {
-		if( 0 < expiry )
-			setExpiry(msg, expiry);
-		add(msg);
-	}
-	
-	/**
-	 * Add mail delivery status listener.
-	 * @param listener AspirinListener object
-	 */
-	public static void addListener(AspirinListener listener) {
-		if( listenerManager == null )
-			listenerManager = new ListenerManager();
-		listenerManager.add(listener);
-	}
-	
-	/**
-	 * Remove an email from delivery.
-	 * @param mailid Unique Aspirin ID of this email.
-	 * @throws MessagingException If removing failed.
-	 */
-	public static void remove(String mailid) throws MessagingException {
-		deliveryManager.remove(mailid);
-	}
-	
-	/**
-	 * Remove delivery status listener.
-	 * @param listener AspirinListener
-	 */
-	public static void removeListener(AspirinListener listener) {
-		if( listenerManager != null )
-			listenerManager.remove(listener);
-	}
-	
-	/**
-	 * It creates a new MimeMessage with standard Aspirin ID header.
-	 * 
-	 * @return new MimeMessage object
-	 * 
-	 */
-	public static MimeMessage createNewMimeMessage() {
-		if( defaultSession == null )
-			defaultSession = Session.getDefaultInstance(System.getProperties());
-		MimeMessage mMesg = new MimeMessage(defaultSession);
-		synchronized (idCounterLock) {
-			long nowTime = System.currentTimeMillis()/1000;
-			String newId = nowTime+"."+Integer.toHexString(idCounter++);
-			try {
-				mMesg.setHeader(Aspirin.HEADER_MAIL_ID, newId);
-			} catch (MessagingException msge) {
-				getLogger().warn("Aspirin Mail ID could not be generated.", msge);
-				msge.printStackTrace();
-			}
-		}
-		return mMesg;
-	}
-	
-	public static Collection<InternetAddress> extractRecipients(MimeMessage message) throws MessagingException {
-		Collection<InternetAddress> recipients = new ArrayList<InternetAddress>();
-		
-		Address[] addresses;
-		Message.RecipientType[] types = new Message.RecipientType[]{
-				RecipientType.TO,
-				RecipientType.CC,
-				RecipientType.BCC
-		};
-		for( Message.RecipientType recType : types )
-		{
-			addresses = message.getRecipients(recType);
-			if (addresses != null)
-			{
-				for (Address addr : addresses)
-				{
-					try {
-						recipients.add((InternetAddress)addr);
-					} catch (Exception e) {
-						getLogger().warn("Recipient parsing failed.", e);
-					}
-				}
-			}
-		}
-		return recipients;
-	}
-	
-	/**
-	 * Format expiry header content.
-	 * @param date Expiry date of a message.
-	 * @return Formatted date of expiry - as String. It could be add as 
-	 * MimeMessage header. Please use HEADER_EXPIRY constant as header name.
-	 */
-	public static String formatExpiry(Date date) {
-		return expiryFormat.format(date);
-	}
 
-	/**
-	 * Decode mail ID from MimeMessage. If no such header was defined, then we 
-	 * get MimeMessage's toString() method result back.
-	 * 
-	 * @param message MimeMessage, which ID needs.
-	 * @return An unique mail id associated to this MimeMessage.
-	 */
-	public static String getMailID(MimeMessage message) {
-		String[] headers;
-		try {
-			headers = message.getHeader(Aspirin.HEADER_MAIL_ID);
-			if( headers != null && 0 < headers.length )
-				return headers[0];
-		} catch (MessagingException e) {
-			getLogger().error("MailID header could not be get from MimeMessage.", e);
-		}
-		return message.toString();
-	}
-	
-	/**
-	 * It gives back expiry value of a message in epoch milliseconds.
-	 * @param message The MimeMessage which expiry is needed.
-	 * @return Expiry in milliseconds.
-	 */
-	public static long getExpiry(MimeMessage message) {
-		String headers[];
-		try {
-			headers = message.getHeader(Aspirin.HEADER_EXPIRY);
-			if( headers != null && 0 < headers.length )
-				return expiryFormat.parse(headers[0]).getTime();
-		} catch (Exception e) {
-			getLogger().error("Expiration header could not be get from MimeMessage.", e);
-		}
-		if( configuration.getExpiry() == Configuration.NEVER_EXPIRES )
-			return Long.MAX_VALUE;
-		try {
-			Date sentDate = message.getReceivedDate();
-			if( sentDate != null )
-				return sentDate.getTime()+configuration.getExpiry();
-		} catch (MessagingException e) {
-			getLogger().error("Expiration calculation could not be based on message date.",e);
-		}
-		return System.currentTimeMillis()+configuration.getExpiry();
-	}
-	
-	public static void setExpiry(MimeMessage message, long expiry) {
-		try {
-			message.setHeader(Aspirin.HEADER_EXPIRY, expiryFormat.format(new Date(System.currentTimeMillis()+expiry)));
-		} catch (MessagingException e) {
-			getLogger().error("Could not set Expiry of the MimeMessage: "+getMailID(message)+".", e);
-		}
-	}
-	
-	public static Logger getLogger() {
-		if( configuration == null ) { return null; }
-		return configuration.getLogger();
-	}
-	
-	public static DeliveryManager getDeliveryManager() {
-		return deliveryManager;
-	}
-	
-	public static ListenerManager getListenerManager() {
-		return listenerManager;
-	}
-	
-	public static void shutdown() {
-		deliveryManager.shutdown();
-	}
+    /**
+     * Formatter to set expiry header. Please, use this formatter to create or
+     * change a current header.
+     */
+    public static final SimpleDateFormat expiryFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+
+    /**
+     * This session is used to generate new MimeMessage objects.
+     */
+    @NotNull
+    private static final AtomicReference<Session> defaultSession = new AtomicReference<>(null);
+    @NotNull
+    private static final Object idCounterLock = new Object();
+    /**
+     * Configuration object of Aspirin.
+     */
+    @NotNull
+    private static final Configuration configuration = Configuration.getInstance();
+    /**
+     * AspirinListener management object. Create on first request.
+     */
+    @NotNull
+    private static final AtomicReference<ListenerManager> listenerManager = new AtomicReference<>(null);
+    /**
+     * Delivery and QoS service management. Create on first request.
+     */
+    @NotNull
+    private static final DeliveryManager deliveryManager = new DeliveryManager();
+    /**
+     * This counter is used to generate unique message ids.
+     */
+    private static Integer idCounter = 0;
+
+    /**
+     * You can get configuration object, which could be changed to set up new
+     * values. Please use this method to set up your Aspirin instance. Of
+     * course default values are enough to simple mail sending.
+     *
+     * @return Configuration object of Aspirin
+     */
+    @NotNull
+    public static Configuration getConfiguration() {
+        return configuration;
+    }
+
+    /**
+     * Add MimeMessage to deliver it.
+     *
+     * @param msg MimeMessage to deliver.
+     * @throws MessagingException If delivery add failed.
+     */
+    protected static void add(MimeMessage msg) throws MessagingException {
+        if (!deliveryManager.isAlive())
+            deliveryManager.start();
+        deliveryManager.add(msg);
+    }
+
+    /**
+     * Add MimeMessage to delivery.
+     *
+     * @param msg    MimeMessage
+     * @param expiry Expiration of this email in milliseconds from now.
+     * @throws MessagingException If delivery add failed.
+     */
+    public static void add(@NotNull MimeMessage msg, long expiry) throws MessagingException {
+        Objects.requireNonNull(msg, "msg");
+
+        if (0L < expiry)
+            setExpiry(msg, expiry);
+        add(msg);
+    }
+
+    /**
+     * Add mail delivery status listener.
+     *
+     * @param listener AspirinListener object
+     */
+    public static void addListener(@NotNull AspirinListener listener) {
+        Objects.requireNonNull(listener, "listener");
+
+        if (listenerManager.get() == null)
+            listenerManager.set(new ListenerManager());
+
+        listenerManager.get().add(listener);
+    }
+
+    /**
+     * Remove an email from delivery.
+     *
+     * @param mailid Unique Aspirin ID of this email.
+     */
+    public static void remove(@NotNull String mailid) {
+        deliveryManager.remove(Objects.requireNonNull(mailid, "mailid"));
+    }
+
+    /**
+     * Remove delivery status listener.
+     *
+     * @param listener AspirinListener
+     */
+    public static void removeListener(@NotNull AspirinListener listener) {
+        if (listenerManager.get() != null)
+            listenerManager.get().remove(listener);
+    }
+
+    /**
+     * It creates a new MimeMessage with standard Aspirin ID header.
+     *
+     * @return new MimeMessage object
+     */
+    @NotNull
+    public static MimeMessage createNewMimeMessage() {
+        if (defaultSession.get() == null)
+            defaultSession.set(Session.getDefaultInstance(System.getProperties()));
+
+        MimeMessage mMesg = new MimeMessage(defaultSession.get());
+        synchronized (idCounterLock) {
+            long nowTime = System.currentTimeMillis() / 1000L;
+            String newId = nowTime + "." + Integer.toHexString(idCounter++);
+            try {
+                mMesg.setHeader(Aspirin.HEADER_MAIL_ID, newId);
+            } catch (MessagingException msge) {
+                getLogger().warn("Aspirin Mail ID could not be generated.", msge);
+            }
+        }
+        return mMesg;
+    }
+
+    @NotNull
+    public static Collection<InternetAddress> extractRecipients(@NotNull MimeMessage message) throws MessagingException {
+        Objects.requireNonNull(message, "message");
+        Collection<InternetAddress> recipients = new ArrayList<>();
+        Address[] addresses;
+
+        Message.RecipientType[] types = {
+                Message.RecipientType.TO,
+                Message.RecipientType.CC,
+                Message.RecipientType.BCC
+        };
+
+        for (Message.RecipientType recType : types) {
+            addresses = message.getRecipients(recType);
+
+            if (addresses != null)
+                for (Address addr : addresses)
+                    try {
+                        recipients.add((InternetAddress) addr);
+                    } catch (RuntimeException e) {
+                        getLogger().warn("Recipient parsing failed.", e);
+                    }
+        }
+
+        return recipients;
+    }
+
+    /**
+     * Format expiry header content.
+     *
+     * @param date Expiry date of a message.
+     * @return Formatted date of expiry - as String. It could be add as
+     * MimeMessage header. Please use HEADER_EXPIRY constant as header name.
+     */
+    @NotNull
+    public static String formatExpiry(@NotNull Date date) {
+        return expiryFormat.format(Objects.requireNonNull(date, "date"));
+    }
+
+    /**
+     * Decode mail ID from Part. If no such header was defined, then we
+     * get MimeMessage's toString() method result back.
+     *
+     * @param message Part, which ID needs.
+     * @return An unique mail id associated to this MimeMessage.
+     */
+    @NotNull
+    public static String getMailID(@NotNull Part message) {
+        Objects.requireNonNull(message, "message");
+        String[] headers;
+
+        try {
+            headers = message.getHeader(Aspirin.HEADER_MAIL_ID);
+            if (headers != null && 0 < headers.length)
+                return headers[0];
+        } catch (MessagingException e) {
+            getLogger().error("MailID header could not be get from MimeMessage.", e);
+        }
+
+        return message.toString();
+    }
+
+    /**
+     * It gives back expiry value of a message in epoch milliseconds.
+     *
+     * @param message The MimeMessage which expiry is needed.
+     * @return Expiry in milliseconds.
+     */
+    public static long getExpiry(MimeMessage message) {
+        String[] headers;
+        try {
+            headers = message.getHeader(Aspirin.HEADER_EXPIRY);
+            if (headers != null && 0 < headers.length)
+                return expiryFormat.parse(headers[0]).getTime();
+        } catch (ParseException | MessagingException e) {
+            getLogger().error("Expiration header could not be get from MimeMessage.", e);
+        }
+        if (configuration.getExpiry() == ConfigurationMBean.NEVER_EXPIRES)
+            return Long.MAX_VALUE;
+        try {
+            Date sentDate = message.getReceivedDate();
+            if (sentDate != null)
+                return sentDate.getTime() + configuration.getExpiry();
+        } catch (MessagingException e) {
+            getLogger().error("Expiration calculation could not be based on message date.", e);
+        }
+        return System.currentTimeMillis() + configuration.getExpiry();
+    }
+
+    public static void setExpiry(@NotNull Part message, long expiry) {
+        Objects.requireNonNull(message, "message");
+
+        try {
+            message.setHeader(Aspirin.HEADER_EXPIRY, expiryFormat.format(new Date(System.currentTimeMillis() + expiry)));
+        } catch (MessagingException e) {
+            getLogger().error("Could not set Expiry of the MimeMessage: " + getMailID(message) + ".", e);
+        }
+    }
+
+    @NotNull
+    public static Logger getLogger() {
+        return configuration.getLogger();
+    }
+
+    @NotNull
+    public static DeliveryManager getDeliveryManager() {
+        return deliveryManager;
+    }
+
+    public static ListenerManager getListenerManager() {
+        return listenerManager.get();
+    }
+
+    public static void shutdown() {
+        deliveryManager.shutdown();
+    }
 
 }

--- a/src/main/java/org/masukomi/aspirin/core/config/Configuration.java
+++ b/src/main/java/org/masukomi/aspirin/core/config/Configuration.java
@@ -468,6 +468,7 @@ public class Configuration implements ConfigurationMBean {
         }
     }
 
+    @Nullable
     @Override
     public String getMailStoreClassName() {
         return (String) configParameters.get(PARAM_MAILSTORE_CLASS);
@@ -481,6 +482,7 @@ public class Configuration implements ConfigurationMBean {
 //		this.mailStoreClassName = className;
     }
 
+    @Nullable
     @Override
     public String getQueueStoreClassName() {
         return (String) configParameters.get(PARAM_QUEUESTORE_CLASS);

--- a/src/main/java/org/masukomi/aspirin/core/config/Configuration.java
+++ b/src/main/java/org/masukomi/aspirin/core/config/Configuration.java
@@ -1,18 +1,18 @@
 /*
  * Created on Jan 5, 2004
- * 
+ *
  * Copyright (c) 2004 Katherine Rhodes (masukomi at masukomi dot org)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,17 +22,9 @@
  * SOFTWARE.
  */
 package org.masukomi.aspirin.core.config;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.ParseException;
-
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.masukomi.aspirin.core.AspirinInternal;
 import org.masukomi.aspirin.core.store.mail.MailStore;
 import org.masukomi.aspirin.core.store.mail.SimpleMailStore;
@@ -41,21 +33,27 @@ import org.masukomi.aspirin.core.store.queue.SimpleQueueStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.ParseException;
+import java.util.*;
+
 
 /**
- * <p>This class represents the configuration of Aspirin. You can configure this 
+ * <p>This class represents the configuration of Aspirin. You can configure this
  * software two ways:</p>
- * 
+ *
  * <ol>
  *   <li>Get the configuration instance and set parameters.</li>
  *   <li>Get the instance and initialize with a Properties object.</li>
  * </ol>
- * 
+ *
  * <p>There is a way to change behavior of Aspirin dynamically. You can use
- * JMX to change configuration parameters. In the parameters list we marked the 
+ * JMX to change configuration parameters. In the parameters list we marked the
  * parameters which are applied immediately. For more information view
  * {@link ConfigurationMBean}.</p>
- * 
+ *
  * <table border="1" summary="Parameters">
  *   <tr>
  *     <th>Name</th>
@@ -65,52 +63,52 @@ import org.slf4j.LoggerFactory;
  *   <tr>
  *     <td>aspirin.delivery.attempt.delay</td>
  *     <td>Integer</td>
- *     <td>The delay of next attempt to delivery in milliseconds. <i>Change by 
+ *     <td>The delay of next attempt to delivery in milliseconds. <i>Change by
  *     JMX applied immediately.</i></td>
  *   </tr>
  *   <tr>
  *     <td>aspirin.delivery.attempt.count</td>
  *     <td>Integer</td>
- *     <td>Maximal number of delivery attempts of an email. <i>Change by JMX 
+ *     <td>Maximal number of delivery attempts of an email. <i>Change by JMX
  *     applied immediately.</i></td>
  *   </tr>
  *   <tr>
  *     <td>aspirin.delivery.bounce-on-failure</td>
  *     <td>Boolean</td>
- *     <td>If true, a bounce email will be send to postmaster on failure. 
+ *     <td>If true, a bounce email will be send to postmaster on failure.
  *     <i>Change by JMX applied immediately.</i></td>
  *   </tr>
  *   <tr>
  *     <td>aspirin.delivery.debug</td>
  *     <td>Boolean</td>
- *     <td>If true, full SMTP communication will be logged. <i>Change by JMX 
+ *     <td>If true, full SMTP communication will be logged. <i>Change by JMX
  *     applied immediately.</i></td>
  *   </tr>
  *   <tr>
  *   	<td>aspirin.delivery.expiry</td>
  *   	<td>Long</td>
- *   	<td>Time of sending expiry in milliseconds. The queue send an email 
- *   	until current time = queueing time + expiry. Default value is -1, it 
- *   	means forever (no expiration time). <i>Change by JMX applied 
+ *   	<td>Time of sending expiry in milliseconds. The queue send an email
+ *   	until current time = queueing time + expiry. Default value is -1, it
+ *   	means forever (no expiration time). <i>Change by JMX applied
  *   	immediately.</i></td>
  *   </tr>
  *   <tr>
  *     <td>aspirin.delivery.threads.active.max</td>
  *     <td>Integer</td>
- *     <td>Maximum number of active delivery threads in the pool. <i>Change by 
+ *     <td>Maximum number of active delivery threads in the pool. <i>Change by
  *     JMX applied immediately.</i></td>
  *   </tr>
  *   <tr>
  *     <td>aspirin.delivery.threads.idle.max</td>
  *     <td>Integer</td>
- *     <td>Maximum number of idle delivery threads in the pool (the deilvery 
- *     threads over this limit will be shutdown). <i>Change by JMX applied 
+ *     <td>Maximum number of idle delivery threads in the pool (the delivery
+ *     threads over this limit will be shutdown). <i>Change by JMX applied
  *     immediately.</i></td>
  *   </tr>
  *   <tr>
  *     <td>aspirin.delivery.timeout</td>
  *     <td>Integer</td>
- *     <td>Socket and {@link Transport} timeout in milliseconds. <i>Change by 
+ *     <td>Socket and {@link Transport} timeout in milliseconds. <i>Change by
  *     JMX applied immediately.</i></td>
  *   </tr>
  *   <tr>
@@ -135,433 +133,448 @@ import org.slf4j.LoggerFactory;
  *   <tr>
  *     <td>aspirin.logger.prefix</td>
  *     <td>String</td>
- *     <td>The prefix of the logger. This will be put in the logs at the first 
+ *     <td>The prefix of the logger. This will be put in the logs at the first
  *     position. <i>Change by JMX applied immediately.</i></td>
  *   </tr>
  *   <tr>
  *     <td>aspirin.postmaster.email</td>
  *     <td>String</td>
- *     <td>The email address of the postmaster. <i>Change by JMX applied 
+ *     <td>The email address of the postmaster. <i>Change by JMX applied
  *     immediately.</i></td>
  *   </tr>
  *   <tr>
  *   	<td>aspirin.mailstore.class</td>
  *   	<td>String</td>
- *   	<td>The class name of mail store. Default class is SimpleMailStore in 
+ *   	<td>The class name of mail store. Default class is SimpleMailStore in
  *   	org.masukomi.aspirin.core.store package.</td>
  *   </tr>
  *   <tr>
  *   	<td>aspirin.queuestore.class</td>
  *   	<td>String</td>
- *   	<td>The class name of queue store. Default class is SimpleQueueStore in 
+ *   	<td>The class name of queue store. Default class is SimpleQueueStore in
  *   	org.masukomi.aspirin.core.queue package.</td>
  *   </tr>
  * </table>
- * 
+ *
  * @author Kate Rhodes masukomi at masukomi dot org
  * @author Laszlo Solova
  */
 public class Configuration implements ConfigurationMBean {
-	
-	private static volatile Configuration instance;
-	private Map<String, Object> configParameters = new HashMap<String, Object>();
-	private static Logger log = null; // inherited from aspirin.logger.name
-	private MailStore mailStore = null;
-	private QueueStore queueStore = null;
-	protected InternetAddress postmaster = null; // inherited from aspirin.postmaster.email
-	private Session mailSession = null;
-	
-	private List<ConfigurationChangeListener> listeners;
-	private Object listenerLock = new Object();
+    private static final String MAIL_MIME_CHARSET = "mail.mime.charset";
+    private static final String MAIL_SMTP_CONNECTIONTIMEOUT = "mail.smtp.connectiontimeout";
+    private static final String MAIL_SMTP_HOST = "mail.smtp.host";
+    private static final String MAIL_SMTP_LOCALHOST = "mail.smtp.localhost";
+    private static final String MAIL_SMTP_TIMEOUT = "mail.smtp.timeout";
+    @Nullable
+    private static Configuration instance;
+    @Nullable
+    private static Logger log; // inherited from aspirin.logger.name
+    @NotNull
+    private final Map<String, Object> configParameters = new HashMap<>();
+    @NotNull
+    private final Object listenerLock = new Object();
+    @Nullable
+    protected InternetAddress postmaster; // inherited from aspirin.postmaster.email
+    @Nullable
+    private MailStore mailStore;
+    @Nullable
+    private QueueStore queueStore;
+    @Nullable
+    private Session mailSession;
+    @Nullable
+    private List<ConfigurationChangeListener> listeners;
 
-	static public Configuration getInstance() {
-		if (instance == null) {
-			instance = new Configuration();
-		}
-		return instance;
-	}
-	
-	public void init(Properties props) {
-		
-		List<Parameter> parameterList = new ArrayList<Configuration.Parameter>();
-		parameterList.add(new Parameter(PARAM_DELIVERY_ATTEMPT_COUNT,		3,				Parameter.TYPE_INTEGER));
-		parameterList.add(new Parameter(PARAM_DELIVERY_ATTEMPT_DELAY,		300000,			Parameter.TYPE_INTEGER));
-		parameterList.add(new Parameter(PARAM_DELIVERY_BOUNCE_ON_FAILURE,	true,			Parameter.TYPE_BOOLEAN));
-		parameterList.add(new Parameter(PARAM_DELIVERY_DEBUG,				false,			Parameter.TYPE_BOOLEAN));
-		parameterList.add(new Parameter(PARAM_DELIVERY_EXPIRY,				-1L,			Parameter.TYPE_LONG));
-		parameterList.add(new Parameter(PARAM_DELIVERY_THREADS_ACTIVE_MAX,	3,				Parameter.TYPE_INTEGER));
-		parameterList.add(new Parameter(PARAM_DELIVERY_THREADS_IDLE_MAX,	3,				Parameter.TYPE_INTEGER));
-		parameterList.add(new Parameter(PARAM_DELIVERY_TIMEOUT,				30000,			Parameter.TYPE_INTEGER));
-		parameterList.add(new Parameter(PARAM_ENCODING,						"UTF-8",		Parameter.TYPE_STRING));
-		parameterList.add(new Parameter(PARAM_HOSTNAME,						"localhost",	Parameter.TYPE_STRING));
-		parameterList.add(new Parameter(PARAM_LOGGER_NAME,					"Aspirin",		Parameter.TYPE_STRING));
-		parameterList.add(new Parameter(PARAM_LOGGER_PREFIX,				"Aspirin ",		Parameter.TYPE_STRING));
-		parameterList.add(new Parameter(PARAM_MAILSTORE_CLASS,				SimpleMailStore.class.getCanonicalName(),	Parameter.TYPE_STRING));
-		parameterList.add(new Parameter(PARAM_POSTMASTER_EMAIL,				null,			Parameter.TYPE_STRING));
-		parameterList.add(new Parameter(PARAM_QUEUESTORE_CLASS,				SimpleQueueStore.class.getCanonicalName(),	Parameter.TYPE_STRING));
-		
-		for( Parameter param : parameterList )
-		{
-			Object o = param.extractValue(props);
-			if( o != null )
-				configParameters.put(param.getName(), o);
-		}
-		
-		log = LoggerFactory.getLogger((String)configParameters.get(PARAM_LOGGER_NAME));
-		setPostmasterEmail((String)configParameters.get(PARAM_POSTMASTER_EMAIL));
-		updateMailSession();
-	}
-	
-	/**
-	 *  
-	 */
-	Configuration() {
-		init(new Properties());
-	}
-	/**
-	 * @return The email address of the postmaster in a MailAddress object.
-	 */
-	public InternetAddress getPostmaster() {
-		return postmaster;
-	}
-	public String getHostname() {
-		return (String)configParameters.get(PARAM_HOSTNAME);
-	}
-	public void setHostname(String hostname) {
-		configParameters.put(PARAM_HOSTNAME, hostname);
-		updateMailSession();
-		notifyListeners(PARAM_HOSTNAME);
-	}
-	public String getEncoding() {
-		return (String)configParameters.get(PARAM_ENCODING);
-	}
-	public void setEncoding(String encoding) {
-		configParameters.put(PARAM_ENCODING, encoding);
+    Configuration() {
+        init(new Properties());
+    }
+
+    public static synchronized Configuration getInstance() {
+        if (instance == null) {
+            instance = new Configuration();
+        }
+        return instance;
+    }
+
+    public void init(@NotNull Properties props) {
+        Objects.requireNonNull(props, "props");
+        Collection<Parameter> parameterList = new ArrayList<>(15);
+        parameterList.add(new Parameter(PARAM_DELIVERY_ATTEMPT_COUNT, 3, Parameter.TYPE_INTEGER));
+        parameterList.add(new Parameter(PARAM_DELIVERY_ATTEMPT_DELAY, 300000, Parameter.TYPE_INTEGER));
+        parameterList.add(new Parameter(PARAM_DELIVERY_BOUNCE_ON_FAILURE, true, Parameter.TYPE_BOOLEAN));
+        parameterList.add(new Parameter(PARAM_DELIVERY_DEBUG, false, Parameter.TYPE_BOOLEAN));
+        parameterList.add(new Parameter(PARAM_DELIVERY_EXPIRY, -1L, Parameter.TYPE_LONG));
+        parameterList.add(new Parameter(PARAM_DELIVERY_THREADS_ACTIVE_MAX, 3, Parameter.TYPE_INTEGER));
+        parameterList.add(new Parameter(PARAM_DELIVERY_THREADS_IDLE_MAX, 3, Parameter.TYPE_INTEGER));
+        parameterList.add(new Parameter(PARAM_DELIVERY_TIMEOUT, 30000, Parameter.TYPE_INTEGER));
+        parameterList.add(new Parameter(PARAM_ENCODING, "UTF-8", Parameter.TYPE_STRING));
+        parameterList.add(new Parameter(PARAM_HOSTNAME, "localhost", Parameter.TYPE_STRING));
+        parameterList.add(new Parameter(PARAM_LOGGER_NAME, "Aspirin", Parameter.TYPE_STRING));
+        parameterList.add(new Parameter(PARAM_LOGGER_PREFIX, "Aspirin ", Parameter.TYPE_STRING));
+        parameterList.add(new Parameter(PARAM_MAILSTORE_CLASS, SimpleMailStore.class.getCanonicalName(), Parameter.TYPE_STRING));
+        parameterList.add(new Parameter(PARAM_POSTMASTER_EMAIL, null, Parameter.TYPE_STRING));
+        parameterList.add(new Parameter(PARAM_QUEUESTORE_CLASS, SimpleQueueStore.class.getCanonicalName(), Parameter.TYPE_STRING));
+
+        parameterList.forEach(param -> {
+            Object o = param.extractValue(props);
+            if (o != null) configParameters.put(param.getName(), o);
+        });
+
+        log = LoggerFactory.getLogger((String) configParameters.get(PARAM_LOGGER_NAME));
+        setPostmasterEmail((String) configParameters.get(PARAM_POSTMASTER_EMAIL));
+        updateMailSession();
+    }
+
+    /**
+     * @return The email address of the postmaster in a MailAddress object.
+     */
+    @Nullable
+    public InternetAddress getPostmaster() {
+        return postmaster;
+    }
+
+    @Nullable
+    public String getHostname() {
+        return (String) configParameters.get(PARAM_HOSTNAME);
+    }
+
+    public void setHostname(@Nullable String hostname) {
+        configParameters.put(PARAM_HOSTNAME, hostname);
+        updateMailSession();
+        notifyListeners(PARAM_HOSTNAME);
+    }
+
+    @Nullable
+    public String getEncoding() {
+        return (String) configParameters.get(PARAM_ENCODING);
+    }
+
+    public void setEncoding(@Nullable String encoding) {
+        configParameters.put(PARAM_ENCODING, encoding);
 //		this.encoding = encoding;
-		updateMailSession();
-		notifyListeners(PARAM_ENCODING);
-	}
+        updateMailSession();
+        notifyListeners(PARAM_ENCODING);
+    }
 
-	@Override
-	public int getDeliveryAttemptCount() {
-		return (Integer)configParameters.get(PARAM_DELIVERY_ATTEMPT_COUNT);
+    @Override
+    public int getDeliveryAttemptCount() {
+        return (Integer) configParameters.get(PARAM_DELIVERY_ATTEMPT_COUNT);
 //		return maxAttempts;
-	}
+    }
 
-	@Override
-	public int getDeliveryAttemptDelay() {
-		return (Integer)configParameters.get(PARAM_DELIVERY_ATTEMPT_DELAY);
-//		return (int)retryInterval;
-	}
-
-	@Override
-	public int getDeliveryThreadsActiveMax() {
-		return (Integer)configParameters.get(PARAM_DELIVERY_THREADS_ACTIVE_MAX);
-	}
-	
-	@Override
-	public int getDeliveryThreadsIdleMax() {
-		return (Integer)configParameters.get(PARAM_DELIVERY_THREADS_IDLE_MAX);
-	}
-
-	@Override
-	public int getDeliveryTimeout() {
-		return (Integer)configParameters.get(PARAM_DELIVERY_TIMEOUT);
-	}
-	
-	@Override
-	public long getExpiry() {
-		return (Long)configParameters.get(PARAM_DELIVERY_EXPIRY);
-	}
-
-	@Override
-	public String getLoggerName() {
-		return (String)configParameters.get(PARAM_LOGGER_NAME);
-	}
-
-	@Override
-	public String getLoggerPrefix() {
-		return (String)configParameters.get(PARAM_LOGGER_PREFIX);
-	}
-	
-	public MailStore getMailStore() {
-		if( mailStore == null )
-		{
-			String mailStoreClassName = (String)configParameters.get(PARAM_MAILSTORE_CLASS);
-			try {
-				Class<?> storeClass = (Class<?>) Class.forName(mailStoreClassName);
-				if( storeClass.getInterfaces()[0].equals(MailStore.class) )
-					mailStore = (MailStore)storeClass.newInstance();
-			} catch (Exception e) {
-				log.error(getClass().getSimpleName()+" Mail store class could not be instantiated. Class="+mailStoreClassName, e);
-				mailStore = new SimpleMailStore();
-			}
-		}
-		return mailStore;
-	}
-	
-	@Override
-	public String getPostmasterEmail() {
-		return postmaster.toString();
-	}
-	
-	public QueueStore getQueueStore() {
-		if( queueStore == null )
-		{
-			String queueStoreClassName = (String)configParameters.get(PARAM_QUEUESTORE_CLASS);
-			try {
-				Class<?> storeClass = (Class<?>) Class.forName(queueStoreClassName);
-				if( storeClass.getInterfaces()[0].equals(QueueStore.class) )
-					queueStore = (QueueStore)storeClass.newInstance();
-			} catch (Exception e) {
-				log.error(getClass().getSimpleName()+" Queue store class could not be instantiated. Class="+queueStoreClassName, e);
-				queueStore = new SimpleQueueStore();
-			}
-		}
-		return queueStore;
-	}
-	
-	@Override
-	public boolean isDeliveryBounceOnFailure() {
-		return (Boolean)configParameters.get(PARAM_DELIVERY_BOUNCE_ON_FAILURE);
-	}
-
-	@Override
-	public boolean isDeliveryDebug() {
-		return (Boolean)configParameters.get(PARAM_DELIVERY_DEBUG);
-	}
-
-	@Override
-	public void setDeliveryAttemptCount(int attemptCount) {
-		configParameters.put(PARAM_DELIVERY_ATTEMPT_COUNT, attemptCount);
+    @Override
+    public void setDeliveryAttemptCount(int attemptCount) {
+        configParameters.put(PARAM_DELIVERY_ATTEMPT_COUNT, attemptCount);
 //		this.maxAttempts = attemptCount;
-		notifyListeners(PARAM_DELIVERY_ATTEMPT_COUNT);
-	}
+        notifyListeners(PARAM_DELIVERY_ATTEMPT_COUNT);
+    }
 
-	@Override
-	public void setDeliveryAttemptDelay(int delay) {
-		configParameters.put(PARAM_DELIVERY_ATTEMPT_DELAY, delay);
+    @Override
+    public int getDeliveryAttemptDelay() {
+        return (Integer) configParameters.get(PARAM_DELIVERY_ATTEMPT_DELAY);
+//		return (int)retryInterval;
+    }
+
+    @Override
+    public void setDeliveryAttemptDelay(int delay) {
+        configParameters.put(PARAM_DELIVERY_ATTEMPT_DELAY, delay);
 //		this.retryInterval = delay;
-		notifyListeners(PARAM_DELIVERY_ATTEMPT_DELAY);
-	}
-	
-	@Override
-	public void setDeliveryBounceOnFailure(boolean bounce) {
-		configParameters.put(PARAM_DELIVERY_BOUNCE_ON_FAILURE, bounce);
-		notifyListeners(PARAM_DELIVERY_BOUNCE_ON_FAILURE);
-	}
+        notifyListeners(PARAM_DELIVERY_ATTEMPT_DELAY);
+    }
 
-	@Override
-	public void setDeliveryDebug(boolean debug) {
-		configParameters.put(PARAM_DELIVERY_DEBUG, debug);
-		updateMailSession();
-		notifyListeners(PARAM_DELIVERY_DEBUG);
-	}
+    @Override
+    public int getDeliveryThreadsActiveMax() {
+        return (Integer) configParameters.get(PARAM_DELIVERY_THREADS_ACTIVE_MAX);
+    }
 
-	@Override
-	public void setDeliveryThreadsActiveMax(int activeThreadsMax) {
-		configParameters.put(PARAM_DELIVERY_THREADS_ACTIVE_MAX, activeThreadsMax);
-		notifyListeners(PARAM_DELIVERY_THREADS_ACTIVE_MAX);
-	}
-	
-	@Override
-	public void setDeliveryThreadsIdleMax(int idleThreadsMax) {
-		configParameters.put(PARAM_DELIVERY_THREADS_IDLE_MAX, idleThreadsMax);
-		notifyListeners(PARAM_DELIVERY_THREADS_IDLE_MAX);
-	}
+    @Override
+    public void setDeliveryThreadsActiveMax(int activeThreadsMax) {
+        configParameters.put(PARAM_DELIVERY_THREADS_ACTIVE_MAX, activeThreadsMax);
+        notifyListeners(PARAM_DELIVERY_THREADS_ACTIVE_MAX);
+    }
 
-	@Override
-	public void setDeliveryTimeout(int timeout) {
-		configParameters.put(PARAM_DELIVERY_TIMEOUT, timeout);
+    @Override
+    public int getDeliveryThreadsIdleMax() {
+        return (Integer) configParameters.get(PARAM_DELIVERY_THREADS_IDLE_MAX);
+    }
+
+    @Override
+    public void setDeliveryThreadsIdleMax(int idleThreadsMax) {
+        configParameters.put(PARAM_DELIVERY_THREADS_IDLE_MAX, idleThreadsMax);
+        notifyListeners(PARAM_DELIVERY_THREADS_IDLE_MAX);
+    }
+
+    @Override
+    public int getDeliveryTimeout() {
+        return (Integer) configParameters.get(PARAM_DELIVERY_TIMEOUT);
+    }
+
+    @Override
+    public void setDeliveryTimeout(int timeout) {
+        configParameters.put(PARAM_DELIVERY_TIMEOUT, timeout);
 //		this.connectionTimeout = timeout;
-		updateMailSession();
-		notifyListeners(PARAM_DELIVERY_TIMEOUT);
-	}
-	
-	@Override
-	public void setExpiry(long expiry) {
-		configParameters.put(PARAM_DELIVERY_EXPIRY, expiry);
-		notifyListeners(PARAM_DELIVERY_EXPIRY);
-	}
+        updateMailSession();
+        notifyListeners(PARAM_DELIVERY_TIMEOUT);
+    }
 
-	@Override
-	public void setLoggerName(String loggerName) {
-		configParameters.put(PARAM_LOGGER_NAME, loggerName);
+    @Override
+    public long getExpiry() {
+        return (Long) configParameters.get(PARAM_DELIVERY_EXPIRY);
+    }
+
+    @Override
+    public void setExpiry(long expiry) {
+        configParameters.put(PARAM_DELIVERY_EXPIRY, expiry);
+        notifyListeners(PARAM_DELIVERY_EXPIRY);
+    }
+
+    @Override
+    @Nullable
+    public String getLoggerName() {
+        return (String) configParameters.get(PARAM_LOGGER_NAME);
+    }
+
+    @Override
+    public void setLoggerName(@Nullable String loggerName) {
+        configParameters.put(PARAM_LOGGER_NAME, loggerName);
 //		Configuration.loggerName = loggerName;
-		log = LoggerFactory.getLogger(loggerName);
-		notifyListeners(PARAM_LOGGER_NAME);
-	}
+        log = LoggerFactory.getLogger(loggerName);
+        notifyListeners(PARAM_LOGGER_NAME);
+    }
 
-	@Override
-	public void setLoggerPrefix(String loggerPrefix) {
-		configParameters.put(PARAM_LOGGER_PREFIX, loggerPrefix);
+    @Override
+    @Nullable
+    public String getLoggerPrefix() {
+        return (String) configParameters.get(PARAM_LOGGER_PREFIX);
+    }
+
+    @Override
+    public void setLoggerPrefix(@Nullable String loggerPrefix) {
+        configParameters.put(PARAM_LOGGER_PREFIX, loggerPrefix);
 //		this.loggerPrefix = loggerPrefix;
-		notifyListeners(PARAM_LOGGER_PREFIX);
-	}
-	
-	public void setMailStore(MailStore mailStore) {
-		this.mailStore = mailStore;
-		notifyListeners(PARAM_MAILSTORE_CLASS);
-	}
+        notifyListeners(PARAM_LOGGER_PREFIX);
+    }
 
-	@Override
-	public void setPostmasterEmail(String emailAddress) {
-		if( emailAddress == null )
-		{
-			this.postmaster = null;
-			return;
-		}
-		try
-		{
-			this.postmaster = new InternetAddress(emailAddress);
-			notifyListeners(PARAM_POSTMASTER_EMAIL);
-		}catch (ParseException e)
-		{
-			log.error(getClass().getSimpleName()+".setPostmasterEmail(): The email address is unparseable.", e);
-		}
-	}
-	
-	public void setQueueStore(QueueStore queueStore) {
-		this.queueStore = queueStore;
-		notifyListeners(PARAM_QUEUESTORE_CLASS);
-	}
-	
-	public void addListener(ConfigurationChangeListener listener) {
-		if( listeners == null )
-			listeners = new ArrayList<ConfigurationChangeListener>();
-		synchronized (listenerLock) {
-			listeners.add(listener);
-		}
-	}
-	
-	public void removeListener(ConfigurationChangeListener listener) {
-		if( listeners != null )
-		{
-			synchronized (listenerLock) {
-				listeners.remove(listener);
-			}
-		}
-	}
-	
-	private void notifyListeners(String changedParameterName) {
-		if( listeners != null && 0 < listeners.size() )
-		{
-			if( log.isInfoEnabled() )
-				log.info(getClass().getSimpleName()+".notifyListeners(): Configuration parameter '"+changedParameterName+"' changed.");
-			synchronized (listenerLock) {
-				for( ConfigurationChangeListener listener : listeners )
-					listener.configChanged(changedParameterName);
-			}
-		}
-	}
+    @NotNull
+    public MailStore getMailStore() {
+        if (mailStore == null) {
+            String mailStoreClassName = (String) configParameters.get(PARAM_MAILSTORE_CLASS);
+            try {
+                Class<?> storeClass = Class.forName(mailStoreClassName);
+                if (storeClass.getInterfaces()[0].equals(MailStore.class))
+                    mailStore = (MailStore) storeClass.getConstructor().newInstance();
+            } catch (Exception e) {
+                log.error(getClass().getSimpleName() + " Mail store class could not be instantiated. Class=" + mailStoreClassName, e);
+                mailStore = new SimpleMailStore();
+            }
+        }
+        return mailStore;
+    }
 
-	@Override
-	public String getMailStoreClassName() {
-		return (String)configParameters.get(PARAM_MAILSTORE_CLASS);
-	}
+    public void setMailStore(@Nullable MailStore mailStore) {
+        this.mailStore = mailStore;
+        notifyListeners(PARAM_MAILSTORE_CLASS);
+    }
 
-	@Override
-	public void setMailStoreClassName(String className) {
-		configParameters.put(PARAM_MAILSTORE_CLASS, className);
-		mailStore = null;
-		notifyListeners(PARAM_MAILSTORE_CLASS);
+    @Override
+    @NotNull
+    public String getPostmasterEmail() {
+        return String.valueOf(postmaster);
+    }
+
+    @Override
+    public void setPostmasterEmail(@Nullable String emailAddress) {
+        if (emailAddress == null) {
+            postmaster = null;
+            return;
+        }
+        try {
+            postmaster = new InternetAddress(emailAddress);
+            notifyListeners(PARAM_POSTMASTER_EMAIL);
+        } catch (ParseException e) {
+            log.error(getClass().getSimpleName() + ".setPostmasterEmail(): The email address is unparseable.", e);
+        }
+    }
+
+    @NotNull
+    public QueueStore getQueueStore() {
+        if (queueStore == null) {
+            String queueStoreClassName = (String) configParameters.get(PARAM_QUEUESTORE_CLASS);
+            try {
+                Class<?> storeClass = Class.forName(queueStoreClassName);
+                if (storeClass.getInterfaces()[0].equals(QueueStore.class))
+                    queueStore = (QueueStore) storeClass.getConstructor().newInstance();
+            } catch (Exception e) {
+                log.error(getClass().getSimpleName() + " Queue store class could not be instantiated. Class=" + queueStoreClassName, e);
+                queueStore = new SimpleQueueStore();
+            }
+        }
+        return queueStore;
+    }
+
+    public void setQueueStore(@Nullable QueueStore queueStore) {
+        this.queueStore = queueStore;
+        notifyListeners(PARAM_QUEUESTORE_CLASS);
+    }
+
+    @Override
+    public boolean isDeliveryBounceOnFailure() {
+        return (Boolean) configParameters.get(PARAM_DELIVERY_BOUNCE_ON_FAILURE);
+    }
+
+    @Override
+    public void setDeliveryBounceOnFailure(boolean bounce) {
+        configParameters.put(PARAM_DELIVERY_BOUNCE_ON_FAILURE, bounce);
+        notifyListeners(PARAM_DELIVERY_BOUNCE_ON_FAILURE);
+    }
+
+    @Override
+    public boolean isDeliveryDebug() {
+        return (Boolean) configParameters.get(PARAM_DELIVERY_DEBUG);
+    }
+
+    @Override
+    public void setDeliveryDebug(boolean debug) {
+        configParameters.put(PARAM_DELIVERY_DEBUG, debug);
+        updateMailSession();
+        notifyListeners(PARAM_DELIVERY_DEBUG);
+    }
+
+    public void addListener(@Nullable ConfigurationChangeListener listener) {
+        if (listeners == null)
+            listeners = new ArrayList<>();
+        synchronized (listenerLock) {
+            listeners.add(listener);
+        }
+    }
+
+    public void removeListener(@Nullable ConfigurationChangeListener listener) {
+        if (listeners != null) {
+            synchronized (listenerLock) {
+                listeners.remove(listener);
+            }
+        }
+    }
+
+    private void notifyListeners(@NotNull String changedParameterName) {
+        Objects.requireNonNull(changedParameterName, "changedParameterName");
+
+        if (listeners != null && !listeners.isEmpty()) {
+            if (log.isInfoEnabled())
+                log.info(getClass().getSimpleName() + ".notifyListeners(): Configuration parameter '" + changedParameterName + "' changed.");
+
+            synchronized (listenerLock) {
+                listeners.forEach(listener -> listener.configChanged(changedParameterName));
+            }
+        }
+    }
+
+    @Override
+    public String getMailStoreClassName() {
+        return (String) configParameters.get(PARAM_MAILSTORE_CLASS);
+    }
+
+    @Override
+    public void setMailStoreClassName(@Nullable String className) {
+        configParameters.put(PARAM_MAILSTORE_CLASS, className);
+        mailStore = null;
+        notifyListeners(PARAM_MAILSTORE_CLASS);
 //		this.mailStoreClassName = className;
-	}
-	
-	@Override
-	public String getQueueStoreClassName() {
-		return (String)configParameters.get(PARAM_QUEUESTORE_CLASS);
-	}
-	
-	@Override
-	public void setQueueStoreClassName(String className) {
-		configParameters.put(PARAM_QUEUESTORE_CLASS, className);
-		queueStore = null;
-		notifyListeners(PARAM_QUEUESTORE_CLASS);
-//		this.queueStoreClassName = className;
-	}
-	
-	public Logger getLogger() {
-		return LoggerFactory.getLogger((String)configParameters.get(PARAM_LOGGER_PREFIX));
-	}
-	
-	public Session getMailSession() {
-		return Session.getInstance(mailSession.getProperties());
-	}
-	
-	public Object getProperty(String name) {
-		return configParameters.get(name);
-	}
-	public void setProperty(String name, Object value) {
-		configParameters.put(name, value);
-	}
-	
-	private static final String MAIL_MIME_CHARSET = "mail.mime.charset";
-	private static final String MAIL_SMTP_CONNECTIONTIMEOUT = "mail.smtp.connectiontimeout";
-	private static final String MAIL_SMTP_HOST = "mail.smtp.host";
-	private static final String MAIL_SMTP_LOCALHOST = "mail.smtp.localhost";
-	private static final String MAIL_SMTP_TIMEOUT = "mail.smtp.timeout";
-	
-	private void updateMailSession() {
-		// Set up default session
-		Properties mailSessionProps = System.getProperties();
-		mailSessionProps.put(MAIL_SMTP_HOST, getHostname()); //The SMTP server to connect to.
-		mailSessionProps.put(MAIL_SMTP_LOCALHOST, getHostname()); //Local host name. Defaults to InetAddress.getLocalHost().getHostName(). Should not normally need to be set if your JDK and your name service are configured properly.
-		mailSessionProps.put(MAIL_MIME_CHARSET, getEncoding()); //The mail.mime.charset System property can be used to specify the default MIME charset to use for encoded words and text parts that don't otherwise specify a charset. Normally, the default MIME charset is derived from the default Java charset, as specified in the file.encoding System property. Most applications will have no need to explicitly set the default MIME charset. In cases where the default MIME charset to be used for mail messages is different than the charset used for files stored on the system, this property should be set.
-		mailSessionProps.put(MAIL_SMTP_CONNECTIONTIMEOUT, getDeliveryTimeout()); //Socket connection timeout value in milliseconds. Default is infinite timeout.
-		mailSessionProps.put(MAIL_SMTP_TIMEOUT, getDeliveryTimeout()); //Socket I/O timeout value in milliseconds. Default is infinite timeout.
-		Session newSession = Session.getInstance(mailSessionProps);
-		
-		// Set communication debug
-		if( ( AspirinInternal.getLogger() == null || AspirinInternal.getLogger().isDebugEnabled() ) && isDeliveryDebug() )
-			newSession.setDebug(true);
-		
-		mailSession = newSession;
-	}
-	
-	private class Parameter {
-		
-		public static final int TYPE_STRING		= 0;
-		public static final int TYPE_INTEGER	= 1;
-		public static final int TYPE_LONG		= 2;
-		public static final int TYPE_BOOLEAN	= 3;
-		
-		private String name;
-		private int type;
-		private Object defaultValue;
-		
-		public Parameter(String name, Object defaultValue, int type) {
-			this.name = name;
-			this.defaultValue = defaultValue;
-			this.type = type;
-		}
-		
-		public String getName() {
-			return name;
-		}
-		
-		Object extractValue(Properties props) {
-			String tempString = props.getProperty(name);
-			if( tempString == null )
-				tempString = System.getProperty(name);
-			
-			if( tempString != null )
-			{
-				switch (type)
-				{
-				case TYPE_INTEGER :
-					return Integer.valueOf(tempString);
-				case TYPE_LONG :
-					return Long.valueOf(tempString);
-				case TYPE_BOOLEAN :
-					return ("true".equalsIgnoreCase(tempString) ) ? Boolean.TRUE : Boolean.FALSE;
-				default:
-					return tempString;
-				}
-			}
-			return defaultValue;
-		}
-		
-	}
+    }
 
+    @Override
+    public String getQueueStoreClassName() {
+        return (String) configParameters.get(PARAM_QUEUESTORE_CLASS);
+    }
+
+    @Override
+    public void setQueueStoreClassName(@Nullable String className) {
+        configParameters.put(PARAM_QUEUESTORE_CLASS, className);
+        queueStore = null;
+        notifyListeners(PARAM_QUEUESTORE_CLASS);
+//		this.queueStoreClassName = className;
+    }
+
+    @NotNull
+    public Logger getLogger() {
+        return LoggerFactory.getLogger((String) configParameters.get(PARAM_LOGGER_PREFIX));
+    }
+
+    @NotNull
+    public Session getMailSession() {
+        return Session.getInstance(mailSession.getProperties());
+    }
+
+    @Nullable
+    public Object getProperty(@NotNull String name) {
+        Objects.requireNonNull(name, "name");
+        return configParameters.get(name);
+    }
+
+    public void setProperty(String name, Object value) {
+        configParameters.put(name, value);
+    }
+
+    private void updateMailSession() {
+        // Set up default session
+        Properties mailSessionProps = System.getProperties();
+        mailSessionProps.setProperty(MAIL_SMTP_HOST, getHostname()); //The SMTP server to connect to.
+        mailSessionProps.setProperty(MAIL_SMTP_LOCALHOST, getHostname()); //Local host name. Defaults to InetAddress.getLocalHost().getHostName(). Should not normally need to be set if your JDK and your name service are configured properly.
+        mailSessionProps.setProperty(MAIL_MIME_CHARSET, getEncoding()); //The mail.mime.charset System property can be used to specify the default MIME charset to use for encoded words and text parts that don't otherwise specify a charset. Normally, the default MIME charset is derived from the default Java charset, as specified in the file.encoding System property. Most applications will have no need to explicitly set the default MIME charset. In cases where the default MIME charset to be used for mail messages is different than the charset used for files stored on the system, this property should be set.
+        mailSessionProps.setProperty(MAIL_SMTP_CONNECTIONTIMEOUT, String.valueOf(getDeliveryTimeout())); //Socket connection timeout value in milliseconds. Default is infinite timeout.
+        mailSessionProps.setProperty(MAIL_SMTP_TIMEOUT, String.valueOf(getDeliveryTimeout())); //Socket I/O timeout value in milliseconds. Default is infinite timeout.
+        Session newSession = Session.getInstance(mailSessionProps);
+
+        // Set communication debug
+        if ((AspirinInternal.getLogger().isDebugEnabled()) && isDeliveryDebug())
+            newSession.setDebug(true);
+
+        mailSession = newSession;
+    }
+
+    private static final class Parameter {
+        public static final int TYPE_STRING = 0;
+        public static final int TYPE_INTEGER = 1;
+        public static final int TYPE_LONG = 2;
+        public static final int TYPE_BOOLEAN = 3;
+        @NotNull
+        private final String name;
+        private final int type;
+        @Nullable
+        private final Object defaultValue;
+
+        Parameter(@NotNull String name, @Nullable Object defaultValue, int type) {
+            this.name = Objects.requireNonNull(name, "name");
+            this.defaultValue = defaultValue;
+            this.type = type;
+        }
+
+        @NotNull
+        public String getName() {
+            return name;
+        }
+
+        @Nullable
+        Object extractValue(@NotNull Properties props) {
+            Objects.requireNonNull(props, "props");
+            String tempString = props.getProperty(name);
+
+            if (tempString == null)
+                tempString = System.getProperty(name);
+
+            if (tempString != null) {
+                switch (type) {
+                    case TYPE_INTEGER:
+                        return Integer.valueOf(tempString);
+                    case TYPE_LONG:
+                        return Long.valueOf(tempString);
+                    case TYPE_BOOLEAN:
+                        return ("true".equalsIgnoreCase(tempString)) ? Boolean.TRUE : Boolean.FALSE;
+                    default:
+                        return tempString;
+                }
+            }
+
+            return defaultValue;
+        }
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/config/ConfigurationChangeListener.java
+++ b/src/main/java/org/masukomi/aspirin/core/config/ConfigurationChangeListener.java
@@ -1,18 +1,21 @@
 package org.masukomi.aspirin.core.config;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
- * <p>This interface is part of configuration subsystem. If a configuration 
- * parameter was changed, the classes which implements this interface could be 
- * notified about these changes. It is requried to allow immediately dynamic 
+ * <p>This interface is part of configuration subsystem. If a configuration
+ * parameter was changed, the classes which implements this interface could be
+ * notified about these changes. It is requried to allow immediately dynamic
  * configuration.</p>
  *
  * @version $Id$
- *
  */
+@FunctionalInterface
 public interface ConfigurationChangeListener {
-	/**
-	 * This method is called when a configuration parameter is changed.
-	 * @param parameterName Name of changed parameter.
-	 */
-	public void configChanged(String parameterName);
+    /**
+     * This method is called when a configuration parameter is changed.
+     *
+     * @param parameterName Name of changed parameter.
+     */
+    void configChanged(@NotNull String parameterName);
 }

--- a/src/main/java/org/masukomi/aspirin/core/config/ConfigurationMBean.java
+++ b/src/main/java/org/masukomi/aspirin/core/config/ConfigurationMBean.java
@@ -1,192 +1,234 @@
 package org.masukomi.aspirin.core.config;
 
-import javax.mail.Transport;
-
 import org.masukomi.aspirin.core.store.mail.FileMailStore;
 import org.masukomi.aspirin.core.store.mail.SimpleMailStore;
 
+import javax.mail.Transport;
+
 /**
- * <p>This is the JMX bean of Aspirin configuration. Some configuration 
+ * <p>This is the JMX bean of Aspirin configuration. Some configuration
  * parameter could be applied immediately.</p>
  *
  * @author Laszlo Solova
- *
  */
 public interface ConfigurationMBean {
-	
-	public static final String PARAM_DELIVERY_ATTEMPT_DELAY			= "aspirin.delivery.attempt.delay";
-	public static final String PARAM_DELIVERY_ATTEMPT_COUNT			= "aspirin.delivery.attempt.count";
-	public static final String PARAM_DELIVERY_BOUNCE_ON_FAILURE		= "aspirin.delivery.bounce-on-failure";
-	public static final String PARAM_DELIVERY_DEBUG					= "aspirin.delivery.debug";
-	public static final String PARAM_DELIVERY_EXPIRY				= "aspirin.delivery.expiry";
-	public static final String PARAM_DELIVERY_THREADS_ACTIVE_MAX	= "aspirin.delivery.threads.active.max";
-	public static final String PARAM_DELIVERY_THREADS_IDLE_MAX		= "aspirin.delivery.threads.idle.max";
-	public static final String PARAM_DELIVERY_TIMEOUT				= "aspirin.delivery.timeout";
-	public static final String PARAM_ENCODING						= "aspirin.encoding";
-	public static final String PARAM_HOSTNAME						= "aspirin.hostname";
-	public static final String PARAM_LOGGER_NAME					= "aspirin.logger.name";
-	public static final String PARAM_LOGGER_PREFIX					= "aspirin.logger.prefix";
-	public static final String PARAM_POSTMASTER_EMAIL				= "aspirin.postmaster.email";
-	public static final String PARAM_MAILSTORE_CLASS				= "aspirin.mailstore.class";
-	public static final String PARAM_QUEUESTORE_CLASS				= "aspirin.queuestore.class";
-	
-	/**
-	 * Value of never expiration. If an email expire is marked with this value, 
-	 * the email sending could be done everytime.
-	 */
-	public static final long NEVER_EXPIRES = -1L;
-	
-	/**
-	 * @return The time between two delivery attempt of an email.
-	 */
-	public int getDeliveryAttemptDelay();
-	/**
-	 * @return The maximal count of delivery attempts of an email. 
-	 */
-	public int getDeliveryAttemptCount();
-	/**
-	 * @return The maximal count of delivery threads running paralel.
-	 */
-	public int getDeliveryThreadsActiveMax();
-	/**
-	 * @return The maximal count of delivery threads stored as idle in delivery 
-	 * pool.
-	 */
-	public int getDeliveryThreadsIdleMax();
-	/**
-	 * @return The socket and {@link Transport} timeout in a delivery.
-	 */
-	public int getDeliveryTimeout();
-	/**
-	 * @return The name of MIME encoding of emails.
-	 */
-	public String getEncoding();
-	/**
-	 * @return The value of default email expiry time.
-	 */
-	public long getExpiry();
-	/**
-	 * @return The name of the logger.
-	 */
-	public String getLoggerName();
-	/**
-	 * @return The prefix appended to the start of the log entries.
-	 */
-	public String getLoggerPrefix();
-	/**
-	 * @return The directory object's class name where the mimemessage objects 
-	 * could be stored.
-	 */
-	public String getMailStoreClassName();
-	/**
-	 * @return The email address of the postmaster.
-	 */
-	public String getPostmasterEmail();
-	/**
-	 * @return The directory object's class name where the email informations 
-	 * could be stored.
-	 */
-	public String getQueueStoreClassName();
-	/**
-	 * @return The hostname of this server. It is used in HELO SMTP command.
-	 */
-	public String getHostname();
-	/**
-	 * @return If true, then a bounce email will be send to postmaster on 
-	 * delivery failures.
-	 */
-	public boolean isDeliveryBounceOnFailure();
-	/**
-	 * @return If true, then the full SMTP communication will be logged. 
-	 */
-	public boolean isDeliveryDebug();
-	/**
-	 * Set the time interval between two delivery attempts of a temporary 
-	 * undeliverable email.
-	 * @param delay The value of delay in milliseconds.
-	 */
-	public void setDeliveryAttemptDelay(int delay);
-	/**
-	 * Set the maximal count of delivery tries of a temporary undeliverable 
-	 * email.
-	 * @param attemptCount The count of deliery attempts.
-	 */
-	public void setDeliveryAttemptCount(int attemptCount);
-	/**
-	 * Set the bounce email sending (on delivery failures).
-	 * @param bounce If true, then a bounce email will be send to postmaster 
-	 * on delivery failures.
-	 */
-	public void setDeliveryBounceOnFailure(boolean bounce);
-	/**
-	 * Set the debug of full SMTP communication. 
-	 * @param debug If true, then the full communication will be logged.
-	 */
-	public void setDeliveryDebug(boolean debug);
-	/**
-	 * Set the maximal count of paralel running delivery threads.
-	 * @param activeThreadsMax The count of delivery threads.
-	 */
-	public void setDeliveryThreadsActiveMax(int activeThreadsMax);
-	/**
-	 * Set the maximal count of idle delivery threads stored in pool.
-	 * @param idleThreadsMax The count of delivery threads.
-	 */
-	public void setDeliveryThreadsIdleMax(int idleThreadsMax);
-	/**
-	 * Set the timeout of {@link Transport} and Socket which is used if 
-	 * communication is too slow.
-	 * @param timeout The value of timeout in milliseconds.
-	 */
-	public void setDeliveryTimeout(int timeout);
-	/**
-	 * Set the encoding of MIME messages. For example: "UTF-8".
-	 * @param encoding The MIME encoding.
-	 */
-	public void setEncoding(String encoding);
-	/**
-	 * Set the default expiry of MIME messages. Default value is -1, it means 
-	 * forever.
-	 * @param expiry The default expiry time. 
-	 */
-	public void setExpiry(long expiry);
-	/**
-	 * If you have got an own logger, you can set up a logger name, which is 
-	 * used in your system. 
-	 * @param loggerName The name of your logger.
-	 */
-	public void setLoggerName(String loggerName);
-	/**
-	 * Set the logger prefix, which will be appended to the start of log 
-	 * entries.
-	 * @param loggerPrefix The prefix string.
-	 */
-	public void setLoggerPrefix(String loggerPrefix);
-	/**
-	 * Set the mail store class name, where MimeMessages will be stored. 
-	 * Built-in stores are {@link SimpleMailStore} and {@link FileMailStore}.
-	 * @param className mail store class
-	 */
-	public void setMailStoreClassName(String className);
-	/**
-	 * Set the email address of postmaster. If delivery failed, you can get an 
-	 * email about the failure to this address.
-	 * @param emailAddress The email address of postmaster.
-	 */
-	public void setPostmasterEmail(String emailAddress);
-	/**
-	 * Set the queue store class name, where queue informations are placed in. 
-	 * Built-in store is the {@link org.masukomi.aspirin.core.store.queue.SimpleQueueStore}.
-	 * @param className queue store class
-	 */
-	public void setQueueStoreClassName(String className);
-	/**
-	 * Set the hostname, which is used in HELO command of SMTP communication. 
-	 * This hostname identifies us for other hosts. If the hostname is invalid 
-	 * or not correctly configured for this server, the delivery could be 
-	 * failed in various reasons. 
-	 * @param hostname The name of this server or application.
-	 */
-	public void setHostname(String hostname);
+    String PARAM_DELIVERY_ATTEMPT_DELAY = "aspirin.delivery.attempt.delay";
+    String PARAM_DELIVERY_ATTEMPT_COUNT = "aspirin.delivery.attempt.count";
+    String PARAM_DELIVERY_BOUNCE_ON_FAILURE = "aspirin.delivery.bounce-on-failure";
+    String PARAM_DELIVERY_DEBUG = "aspirin.delivery.debug";
+    String PARAM_DELIVERY_EXPIRY = "aspirin.delivery.expiry";
+    String PARAM_DELIVERY_THREADS_ACTIVE_MAX = "aspirin.delivery.threads.active.max";
+    String PARAM_DELIVERY_THREADS_IDLE_MAX = "aspirin.delivery.threads.idle.max";
+    String PARAM_DELIVERY_TIMEOUT = "aspirin.delivery.timeout";
+    String PARAM_ENCODING = "aspirin.encoding";
+    String PARAM_HOSTNAME = "aspirin.hostname";
+    String PARAM_LOGGER_NAME = "aspirin.logger.name";
+    String PARAM_LOGGER_PREFIX = "aspirin.logger.prefix";
+    String PARAM_POSTMASTER_EMAIL = "aspirin.postmaster.email";
+    String PARAM_MAILSTORE_CLASS = "aspirin.mailstore.class";
+    String PARAM_QUEUESTORE_CLASS = "aspirin.queuestore.class";
+
+    /**
+     * Value of never expiration. If an email expire is marked with this value,
+     * the email sending could be done everytime.
+     */
+    long NEVER_EXPIRES = -1L;
+
+    /**
+     * @return The time between two delivery attempt of an email.
+     */
+    int getDeliveryAttemptDelay();
+
+    /**
+     * Set the time interval between two delivery attempts of a temporary
+     * undeliverable email.
+     *
+     * @param delay The value of delay in milliseconds.
+     */
+    void setDeliveryAttemptDelay(int delay);
+
+    /**
+     * @return The maximal count of delivery attempts of an email.
+     */
+    int getDeliveryAttemptCount();
+
+    /**
+     * Set the maximal count of delivery tries of a temporary undeliverable
+     * email.
+     *
+     * @param attemptCount The count of deliery attempts.
+     */
+    void setDeliveryAttemptCount(int attemptCount);
+
+    /**
+     * @return The maximal count of delivery threads running paralel.
+     */
+    int getDeliveryThreadsActiveMax();
+
+    /**
+     * Set the maximal count of paralel running delivery threads.
+     *
+     * @param activeThreadsMax The count of delivery threads.
+     */
+    void setDeliveryThreadsActiveMax(int activeThreadsMax);
+
+    /**
+     * @return The maximal count of delivery threads stored as idle in delivery
+     * pool.
+     */
+    int getDeliveryThreadsIdleMax();
+
+    /**
+     * Set the maximal count of idle delivery threads stored in pool.
+     *
+     * @param idleThreadsMax The count of delivery threads.
+     */
+    void setDeliveryThreadsIdleMax(int idleThreadsMax);
+
+    /**
+     * @return The socket and {@link Transport} timeout in a delivery.
+     */
+    int getDeliveryTimeout();
+
+    /**
+     * Set the timeout of {@link Transport} and Socket which is used if
+     * communication is too slow.
+     *
+     * @param timeout The value of timeout in milliseconds.
+     */
+    void setDeliveryTimeout(int timeout);
+
+    /**
+     * @return The name of MIME encoding of emails.
+     */
+    String getEncoding();
+
+    /**
+     * Set the encoding of MIME messages. For example: "UTF-8".
+     *
+     * @param encoding The MIME encoding.
+     */
+    void setEncoding(String encoding);
+
+    /**
+     * @return The value of default email expiry time.
+     */
+    long getExpiry();
+
+    /**
+     * Set the default expiry of MIME messages. Default value is -1, it means
+     * forever.
+     *
+     * @param expiry The default expiry time.
+     */
+    void setExpiry(long expiry);
+
+    /**
+     * @return The name of the logger.
+     */
+    String getLoggerName();
+
+    /**
+     * If you have got an own logger, you can set up a logger name, which is
+     * used in your system.
+     *
+     * @param loggerName The name of your logger.
+     */
+    void setLoggerName(String loggerName);
+
+    /**
+     * @return The prefix appended to the start of the log entries.
+     */
+    String getLoggerPrefix();
+
+    /**
+     * Set the logger prefix, which will be appended to the start of log
+     * entries.
+     *
+     * @param loggerPrefix The prefix string.
+     */
+    void setLoggerPrefix(String loggerPrefix);
+
+    /**
+     * @return The directory object's class name where the mimemessage objects
+     * could be stored.
+     */
+    String getMailStoreClassName();
+
+    /**
+     * Set the mail store class name, where MimeMessages will be stored.
+     * Built-in stores are {@link SimpleMailStore} and {@link FileMailStore}.
+     *
+     * @param className mail store class
+     */
+    void setMailStoreClassName(String className);
+
+    /**
+     * @return The email address of the postmaster.
+     */
+    String getPostmasterEmail();
+
+    /**
+     * Set the email address of postmaster. If delivery failed, you can get an
+     * email about the failure to this address.
+     *
+     * @param emailAddress The email address of postmaster.
+     */
+    void setPostmasterEmail(String emailAddress);
+
+    /**
+     * @return The directory object's class name where the email informations
+     * could be stored.
+     */
+    String getQueueStoreClassName();
+
+    /**
+     * Set the queue store class name, where queue informations are placed in.
+     * Built-in store is the {@link org.masukomi.aspirin.core.store.queue.SimpleQueueStore}.
+     *
+     * @param className queue store class
+     */
+    void setQueueStoreClassName(String className);
+
+    /**
+     * @return The hostname of this server. It is used in HELO SMTP command.
+     */
+    String getHostname();
+
+    /**
+     * Set the hostname, which is used in HELO command of SMTP communication.
+     * This hostname identifies us for other hosts. If the hostname is invalid
+     * or not correctly configured for this server, the delivery could be
+     * failed in various reasons.
+     *
+     * @param hostname The name of this server or application.
+     */
+    void setHostname(String hostname);
+
+    /**
+     * @return If true, then a bounce email will be send to postmaster on
+     * delivery failures.
+     */
+    boolean isDeliveryBounceOnFailure();
+
+    /**
+     * Set the bounce email sending (on delivery failures).
+     *
+     * @param bounce If true, then a bounce email will be send to postmaster
+     *               on delivery failures.
+     */
+    void setDeliveryBounceOnFailure(boolean bounce);
+
+    /**
+     * @return If true, then the full SMTP communication will be logged.
+     */
+    boolean isDeliveryDebug();
+
+    /**
+     * Set the debug of full SMTP communication.
+     *
+     * @param debug If true, then the full communication will be logged.
+     */
+    void setDeliveryDebug(boolean debug);
 
 }

--- a/src/main/java/org/masukomi/aspirin/core/config/ConfigurationMBean.java
+++ b/src/main/java/org/masukomi/aspirin/core/config/ConfigurationMBean.java
@@ -1,5 +1,7 @@
 package org.masukomi.aspirin.core.config;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.masukomi.aspirin.core.store.mail.FileMailStore;
 import org.masukomi.aspirin.core.store.mail.SimpleMailStore;
 
@@ -12,21 +14,21 @@ import javax.mail.Transport;
  * @author Laszlo Solova
  */
 public interface ConfigurationMBean {
-    String PARAM_DELIVERY_ATTEMPT_DELAY = "aspirin.delivery.attempt.delay";
-    String PARAM_DELIVERY_ATTEMPT_COUNT = "aspirin.delivery.attempt.count";
-    String PARAM_DELIVERY_BOUNCE_ON_FAILURE = "aspirin.delivery.bounce-on-failure";
-    String PARAM_DELIVERY_DEBUG = "aspirin.delivery.debug";
-    String PARAM_DELIVERY_EXPIRY = "aspirin.delivery.expiry";
-    String PARAM_DELIVERY_THREADS_ACTIVE_MAX = "aspirin.delivery.threads.active.max";
-    String PARAM_DELIVERY_THREADS_IDLE_MAX = "aspirin.delivery.threads.idle.max";
-    String PARAM_DELIVERY_TIMEOUT = "aspirin.delivery.timeout";
-    String PARAM_ENCODING = "aspirin.encoding";
-    String PARAM_HOSTNAME = "aspirin.hostname";
-    String PARAM_LOGGER_NAME = "aspirin.logger.name";
-    String PARAM_LOGGER_PREFIX = "aspirin.logger.prefix";
-    String PARAM_POSTMASTER_EMAIL = "aspirin.postmaster.email";
-    String PARAM_MAILSTORE_CLASS = "aspirin.mailstore.class";
-    String PARAM_QUEUESTORE_CLASS = "aspirin.queuestore.class";
+    @NotNull String PARAM_DELIVERY_ATTEMPT_DELAY = "aspirin.delivery.attempt.delay";
+    @NotNull String PARAM_DELIVERY_ATTEMPT_COUNT = "aspirin.delivery.attempt.count";
+    @NotNull String PARAM_DELIVERY_BOUNCE_ON_FAILURE = "aspirin.delivery.bounce-on-failure";
+    @NotNull String PARAM_DELIVERY_DEBUG = "aspirin.delivery.debug";
+    @NotNull String PARAM_DELIVERY_EXPIRY = "aspirin.delivery.expiry";
+    @NotNull String PARAM_DELIVERY_THREADS_ACTIVE_MAX = "aspirin.delivery.threads.active.max";
+    @NotNull String PARAM_DELIVERY_THREADS_IDLE_MAX = "aspirin.delivery.threads.idle.max";
+    @NotNull String PARAM_DELIVERY_TIMEOUT = "aspirin.delivery.timeout";
+    @NotNull String PARAM_ENCODING = "aspirin.encoding";
+    @NotNull String PARAM_HOSTNAME = "aspirin.hostname";
+    @NotNull String PARAM_LOGGER_NAME = "aspirin.logger.name";
+    @NotNull String PARAM_LOGGER_PREFIX = "aspirin.logger.prefix";
+    @NotNull String PARAM_POSTMASTER_EMAIL = "aspirin.postmaster.email";
+    @NotNull String PARAM_MAILSTORE_CLASS = "aspirin.mailstore.class";
+    @NotNull String PARAM_QUEUESTORE_CLASS = "aspirin.queuestore.class";
 
     /**
      * Value of never expiration. If an email expire is marked with this value,
@@ -101,6 +103,7 @@ public interface ConfigurationMBean {
     /**
      * @return The name of MIME encoding of emails.
      */
+    @Nullable
     String getEncoding();
 
     /**
@@ -126,6 +129,7 @@ public interface ConfigurationMBean {
     /**
      * @return The name of the logger.
      */
+    @Nullable
     String getLoggerName();
 
     /**
@@ -139,6 +143,7 @@ public interface ConfigurationMBean {
     /**
      * @return The prefix appended to the start of the log entries.
      */
+    @Nullable
     String getLoggerPrefix();
 
     /**
@@ -147,12 +152,13 @@ public interface ConfigurationMBean {
      *
      * @param loggerPrefix The prefix string.
      */
-    void setLoggerPrefix(String loggerPrefix);
+    void setLoggerPrefix(@Nullable String loggerPrefix);
 
     /**
      * @return The directory object's class name where the mimemessage objects
      * could be stored.
      */
+    @Nullable
     String getMailStoreClassName();
 
     /**
@@ -161,11 +167,12 @@ public interface ConfigurationMBean {
      *
      * @param className mail store class
      */
-    void setMailStoreClassName(String className);
+    void setMailStoreClassName(@Nullable String className);
 
     /**
      * @return The email address of the postmaster.
      */
+    @NotNull
     String getPostmasterEmail();
 
     /**
@@ -174,12 +181,13 @@ public interface ConfigurationMBean {
      *
      * @param emailAddress The email address of postmaster.
      */
-    void setPostmasterEmail(String emailAddress);
+    void setPostmasterEmail(@Nullable String emailAddress);
 
     /**
      * @return The directory object's class name where the email informations
      * could be stored.
      */
+    @Nullable
     String getQueueStoreClassName();
 
     /**
@@ -188,11 +196,12 @@ public interface ConfigurationMBean {
      *
      * @param className queue store class
      */
-    void setQueueStoreClassName(String className);
+    void setQueueStoreClassName(@Nullable String className);
 
     /**
      * @return The hostname of this server. It is used in HELO SMTP command.
      */
+    @Nullable
     String getHostname();
 
     /**
@@ -203,7 +212,7 @@ public interface ConfigurationMBean {
      *
      * @param hostname The name of this server or application.
      */
-    void setHostname(String hostname);
+    void setHostname(@Nullable String hostname);
 
     /**
      * @return If true, then a bounce email will be send to postmaster on
@@ -230,5 +239,4 @@ public interface ConfigurationMBean {
      * @param debug If true, then the full communication will be logged.
      */
     void setDeliveryDebug(boolean debug);
-
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryContext.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryContext.java
@@ -38,7 +38,8 @@ public class DeliveryContext {
         return this;
     }
 
-    public @Nullable MimeMessage getMessage() {
+    @Nullable
+    public MimeMessage getMessage() {
         return message;
     }
 
@@ -47,7 +48,8 @@ public class DeliveryContext {
         return this;
     }
 
-    public @Nullable Session getMailSession() {
+    @Nullable
+    public Session getMailSession() {
         return mailSession;
     }
 
@@ -57,7 +59,8 @@ public class DeliveryContext {
         return this;
     }
 
-    public @NotNull Map<String, Object> getContextVariables() {
+    @NotNull
+    public Map<String, Object> getContextVariables() {
         return contextVariables;
     }
 
@@ -83,6 +86,7 @@ public class DeliveryContext {
             ctxToString = getClass().getSimpleName() + " [" +
                     "qi=" + queueInfo +
                     "]; ";
+
         return ctxToString;
     }
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryContext.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryContext.java
@@ -1,72 +1,88 @@
 package org.masukomi.aspirin.core.delivery;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.masukomi.aspirin.core.store.queue.QueueInfo;
 
 import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
-
-import org.masukomi.aspirin.core.store.queue.QueueInfo;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
- * This class is the context of a delivery which contains all required 
+ * This class is the context of a delivery which contains all required
  * informations used or created in the delivery process.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public class DeliveryContext {
-	private QueueInfo queueInfo;
-	public QueueInfo getQueueInfo() {
-		return queueInfo;
-	}
-	public DeliveryContext setQueueInfo(QueueInfo queueInfo) {
-		this.queueInfo = queueInfo;
-		return this;
-	}
-	private MimeMessage message;
-	public MimeMessage getMessage() {
-		return message;
-	}
-	public DeliveryContext setMessage(MimeMessage message) {
-		this.message = message;
-		return this;
-	}
-	private Session mailSession;
-	public Session getMailSession() {
-		return mailSession;
-	}
-	public DeliveryContext setMailSession(Session mailSession) {
-		this.mailSession = mailSession;
-		return this;
-	}
-	
-	private Map<String, Object> contextVariables = new HashMap<String, Object>();
-	public Map<String, Object> getContextVariables() {
-		return contextVariables;
-	}
-	public void addContextVariable(String name, Object variable) {
-		contextVariables.put(name, variable);
-	}
-	@SuppressWarnings("unchecked")
-	public <T> T getContextVariable(String name) {
-		if( contextVariables.containsKey(name) )
-			return (T)contextVariables.get(name);
-		return null;
-	}
-	
-	private transient String ctxToString;
-	@Override
-	public String toString() {
-		if( ctxToString == null )
-		{
-			StringBuilder sb = new StringBuilder();
-			sb.append(getClass().getSimpleName()).append(" [");
-			sb.append("qi=").append(queueInfo);
-			sb.append("]; ");
-			ctxToString = sb.toString();
-		}
-		return ctxToString;
-	}
+    @NotNull
+    private final Map<String, Object> contextVariables = new HashMap<>();
+    @Nullable
+    private QueueInfo queueInfo;
+    @Nullable
+    private MimeMessage message;
+    @Nullable
+    private Session mailSession;
+    @Nullable
+    private String ctxToString;
 
+    @Nullable
+    public QueueInfo getQueueInfo() {
+        return queueInfo;
+    }
+
+    public DeliveryContext setQueueInfo(@Nullable QueueInfo queueInfo) {
+        this.queueInfo = queueInfo;
+        return this;
+    }
+
+    public @Nullable MimeMessage getMessage() {
+        return message;
+    }
+
+    public DeliveryContext setMessage(@Nullable MimeMessage message) {
+        this.message = message;
+        return this;
+    }
+
+    public @Nullable Session getMailSession() {
+        return mailSession;
+    }
+
+    @NotNull
+    public DeliveryContext setMailSession(@Nullable Session mailSession) {
+        this.mailSession = mailSession;
+        return this;
+    }
+
+    public @NotNull Map<String, Object> getContextVariables() {
+        return contextVariables;
+    }
+
+    public void addContextVariable(@NotNull String name, @Nullable Object variable) {
+        contextVariables.put(Objects.requireNonNull(name, "name"), variable);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    public <T> T getContextVariable(@NotNull String name) {
+        Objects.requireNonNull(name, "name");
+
+        if (contextVariables.containsKey(name))
+            return (T) contextVariables.get(name);
+
+        return null;
+    }
+
+    @Override
+    @NotNull
+    public String toString() {
+        if (ctxToString == null)
+            ctxToString = getClass().getSimpleName() + " [" +
+                    "qi=" + queueInfo +
+                    "]; ";
+        return ctxToString;
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryException.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryException.java
@@ -1,32 +1,32 @@
 package org.masukomi.aspirin.core.delivery;
 
+import org.jetbrains.annotations.Nullable;
+
 import javax.mail.MessagingException;
 
 /**
- * 
  * @author Laszlo Solova
- *
  */
 public class DeliveryException extends MessagingException {
-	private static final long serialVersionUID = -5388667812025531029L;
-	
-	private boolean permanent = true;
-	
-	public boolean isPermanent() {
-		return permanent;
-	}
+    private static final long serialVersionUID = -5388667812025531029L;
 
-	public DeliveryException() {
-	}
+    private final boolean permanent;
 
-	public DeliveryException(String s, boolean permanent) {
-		super(s);
-		this.permanent = permanent;
-	}
+    public DeliveryException() {
+        permanent = true;
+    }
 
-	public DeliveryException(String s, boolean permanent, Exception e) {
-		super(s, e);
-		this.permanent = permanent;
-	}
+    public DeliveryException(@Nullable String s, boolean permanent) {
+        super(s);
+        this.permanent = permanent;
+    }
 
+    public DeliveryException(@Nullable String s, boolean permanent, Exception e) {
+        super(s, e);
+        this.permanent = permanent;
+    }
+
+    public boolean isPermanent() {
+        return permanent;
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryHandler.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryHandler.java
@@ -1,15 +1,16 @@
 package org.masukomi.aspirin.core.delivery;
 
+import org.jetbrains.annotations.NotNull;
 import org.masukomi.aspirin.core.config.Configuration;
 
 /**
  * This interface defines an atomic part of delivery chain.
- * A DeliveryHandler is a particular task in the delivery chain. You can create 
+ * A DeliveryHandler is a particular task in the delivery chain. You can create
  * your own chain in the {@link Configuration}.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
+@FunctionalInterface
 public interface DeliveryHandler {
-	public void handle(DeliveryContext dCtx) throws DeliveryException;
+    void handle(@NotNull DeliveryContext dCtx) throws DeliveryException;
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryMaintenanceThread.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryMaintenanceThread.java
@@ -1,63 +1,60 @@
 package org.masukomi.aspirin.core.delivery;
 
-import java.util.List;
-
 import org.masukomi.aspirin.core.AspirinInternal;
 import org.masukomi.aspirin.core.store.mail.MailStore;
 import org.masukomi.aspirin.core.store.queue.QueueStore;
 
+import java.util.List;
+
 /**
- * This is a maintenance thread, to clean up stores - remove all finished 
+ * This is a maintenance thread, to clean up stores - remove all finished
  * mails from these objects. This is very useful for long-time runs.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public class DeliveryMaintenanceThread extends Thread {
-	
-	private boolean running = false;
-	
-	public DeliveryMaintenanceThread() {
-		this.setDaemon(true);
-	}
-	
-	@Override
-	public void run() {
-		AspirinInternal.getLogger().info("Maintenance thread started.");
-		running = true;
-		while( running )
-		{
-			try {
-				synchronized (this) {
-					wait(3600000);
-				}
-			} catch (InterruptedException ie) {
-				running = false;
-				AspirinInternal.getLogger().info("Maintenance thread goes down.");
-			}
-			// Maintain queues in every hour
-			try {
-				QueueStore queueStore = AspirinInternal.getConfiguration().getQueueStore();
-				MailStore mailStore = AspirinInternal.getConfiguration().getMailStore();
-				List<String> usedMailIds = queueStore.clean();
-				List<String> mailStoreMailIds = mailStore.getMailIds();
-				AspirinInternal.getLogger().debug("Maintenance running: usedMailIds: {}, mailStoreMailIds: {}.",new Object[]{usedMailIds.size(), mailStoreMailIds.size()});
-				if( mailStoreMailIds.removeAll(usedMailIds) )
-				{
-					for( String unusedMailId : mailStoreMailIds )
-						mailStore.remove(unusedMailId);
-				}
-			} catch (Exception e) {
-				AspirinInternal.getLogger().error("Maintenance failed.",e);
-			}
-		}
-	}
-	
-	public void shutdown() {
-		running = false;
-		synchronized (this) {
-			notify();
-		}
-	}
+    private boolean running;
 
+    public DeliveryMaintenanceThread() {
+        setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+        AspirinInternal.getLogger().info("Maintenance thread started.");
+        running = true;
+        while (running) {
+            try {
+                synchronized (this) {
+                    wait(3600000);
+                }
+            } catch (InterruptedException ie) {
+                running = false;
+                AspirinInternal.getLogger().info("Maintenance thread goes down.");
+            }
+            // Maintain queues in every hour
+            try {
+                QueueStore queueStore = AspirinInternal.getConfiguration().getQueueStore();
+                MailStore mailStore = AspirinInternal.getConfiguration().getMailStore();
+                List<String> usedMailIds = queueStore.clean();
+                List<String> mailStoreMailIds = mailStore.getMailIds();
+
+                AspirinInternal.getLogger().debug(
+                        "Maintenance running: usedMailIds: {}, mailStoreMailIds: {}.",
+                        usedMailIds.size(),
+                        mailStoreMailIds.size());
+
+                if (mailStoreMailIds.removeAll(usedMailIds)) mailStoreMailIds.forEach(mailStore::remove);
+            } catch (Exception e) {
+                AspirinInternal.getLogger().error("Maintenance failed.", e);
+            }
+        }
+    }
+
+    public void shutdown() {
+        running = false;
+        synchronized (this) {
+            notifyAll();
+        }
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryMaintenanceThread.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryMaintenanceThread.java
@@ -4,7 +4,7 @@ import org.masukomi.aspirin.core.AspirinInternal;
 import org.masukomi.aspirin.core.store.mail.MailStore;
 import org.masukomi.aspirin.core.store.queue.QueueStore;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * This is a maintenance thread, to clean up stores - remove all finished
@@ -23,6 +23,7 @@ public class DeliveryMaintenanceThread extends Thread {
     public void run() {
         AspirinInternal.getLogger().info("Maintenance thread started.");
         running = true;
+
         while (running) {
             try {
                 synchronized (this) {
@@ -32,12 +33,13 @@ public class DeliveryMaintenanceThread extends Thread {
                 running = false;
                 AspirinInternal.getLogger().info("Maintenance thread goes down.");
             }
+
             // Maintain queues in every hour
             try {
                 QueueStore queueStore = AspirinInternal.getConfiguration().getQueueStore();
                 MailStore mailStore = AspirinInternal.getConfiguration().getMailStore();
-                List<String> usedMailIds = queueStore.clean();
-                List<String> mailStoreMailIds = mailStore.getMailIds();
+                Collection<String> usedMailIds = queueStore.clean();
+                Collection<String> mailStoreMailIds = mailStore.getMailIds();
 
                 AspirinInternal.getLogger().debug(
                         "Maintenance running: usedMailIds: {}, mailStoreMailIds: {}.",
@@ -53,6 +55,7 @@ public class DeliveryMaintenanceThread extends Thread {
 
     public void shutdown() {
         running = false;
+
         synchronized (this) {
             notifyAll();
         }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryManager.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryManager.java
@@ -174,6 +174,7 @@ public final class DeliveryManager extends Thread implements ConfigurationChange
                 } else {
                     if (AspirinInternal.getLogger().isTraceEnabled() && 0 < queueStore.size())
                         AspirinInternal.getLogger().trace("DeliveryManager.run(): There is no sendable item in the queue. Fallback to waiting state for a minute.");
+
                     synchronized (this) {
                         try {
                             /*
@@ -188,8 +189,7 @@ public final class DeliveryManager extends Thread implements ConfigurationChange
                 }
 
             } catch (UnsupportedOperationException t) {
-                if (qi != null)
-                    release(qi);
+                if (qi != null) release(qi);
             }
 
         }
@@ -233,6 +233,7 @@ public final class DeliveryManager extends Thread implements ConfigurationChange
     @Override
     public void configChanged(@NotNull String parameterName) {
         Objects.requireNonNull(parameterName, "parameterName");
+
         synchronized (mailingLock) {
             if (parameterName.equals(ConfigurationMBean.PARAM_MAILSTORE_CLASS))
                 mailStore = AspirinInternal.getConfiguration().getMailStore();
@@ -253,12 +254,14 @@ public final class DeliveryManager extends Thread implements ConfigurationChange
 
     public void shutdown() {
         running = false;
+
         try {
             deliveryThreadObjectPool.close();
             deliveryThreadObjectPool.clear();
         } catch (Exception e) {
             AspirinInternal.getLogger().error("DeliveryManager.shutdown() failed.", e);
         }
+
         maintenanceThread.shutdown();
     }
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryManager.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryManager.java
@@ -1,18 +1,10 @@
 package org.masukomi.aspirin.core.delivery;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NoSuchElementException;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-
 import org.apache.commons.pool.ObjectPool;
 import org.apache.commons.pool.impl.GenericObjectPool;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.masukomi.aspirin.core.AspirinInternal;
-import org.masukomi.aspirin.core.config.Configuration;
 import org.masukomi.aspirin.core.config.ConfigurationChangeListener;
 import org.masukomi.aspirin.core.config.ConfigurationMBean;
 import org.masukomi.aspirin.core.dns.ResolveHost;
@@ -21,232 +13,252 @@ import org.masukomi.aspirin.core.store.queue.DeliveryState;
 import org.masukomi.aspirin.core.store.queue.QueueInfo;
 import org.masukomi.aspirin.core.store.queue.QueueStore;
 
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.util.*;
+
 /**
  * This class is the manager of delivery. It is instantiated by Aspirin class.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public final class DeliveryManager extends Thread implements ConfigurationChangeListener {
-	private MailStore mailStore;
-	private QueueStore queueStore;
-	private DeliveryMaintenanceThread maintenanceThread;
-	private Object mailingLock = new Object();
-	private ObjectPool deliveryThreadObjectPool = null;
-	private boolean running = false;
-	private GenericPoolableDeliveryThreadFactory deliveryThreadObjectFactory = null;
-	private Map<String, DeliveryHandler> deliveryHandlers = new HashMap<String, DeliveryHandler>();
-	
-	public DeliveryManager() {
-		// Set up default objects.
-		this.setName("Aspirin-"+getClass().getSimpleName()+"-"+getId());
-		
-		// Configure pool of DeliveryThread threads
-		GenericObjectPool.Config gopConf = new GenericObjectPool.Config();
-		gopConf.lifo = false;
-		gopConf.maxActive = AspirinInternal.getConfiguration().getDeliveryThreadsActiveMax();
-		gopConf.maxIdle = AspirinInternal.getConfiguration().getDeliveryThreadsIdleMax();
-		gopConf.maxWait = 5000;
-		gopConf.testOnReturn = true;
-		gopConf.whenExhaustedAction = GenericObjectPool.WHEN_EXHAUSTED_BLOCK;
-		
-		// Create DeliveryThread object factory used in pool
-		deliveryThreadObjectFactory = new GenericPoolableDeliveryThreadFactory();
-		
-		// Create pool
-		deliveryThreadObjectPool = new GenericObjectPool(deliveryThreadObjectFactory,gopConf);
-		
-		// Initialize object factory of pool
-		deliveryThreadObjectFactory.init(new ThreadGroup("DeliveryThreadGroup"),deliveryThreadObjectPool);
-		
-		// Set up stores and configuration listener 
-		queueStore = AspirinInternal.getConfiguration().getQueueStore();
-		queueStore.init();
-		
-		mailStore = AspirinInternal.getConfiguration().getMailStore();
-		mailStore.init();
-		
-		maintenanceThread = new DeliveryMaintenanceThread();
-		maintenanceThread.start();
-		
-		// Set up deliveryhandlers
-		// TODO create by configuration
-		deliveryHandlers.put(SendMessage.class.getCanonicalName(), new SendMessage());
-		deliveryHandlers.put(ResolveHost.class.getCanonicalName(), new ResolveHost());
-		
-		AspirinInternal.getConfiguration().addListener(this);
-	}
-	
-	public String add(MimeMessage mimeMessage) throws MessagingException {
-		String mailid = AspirinInternal.getMailID(mimeMessage);
-		long expiry = AspirinInternal.getExpiry(mimeMessage);
-		Collection<InternetAddress> recipients = AspirinInternal.extractRecipients(mimeMessage);
-		synchronized (mailingLock) {
-			mailStore.set(mailid, mimeMessage);
-			queueStore.add(mailid, expiry, recipients);
-		}
-		return mailid;
-	}
-	
-	public MimeMessage get(QueueInfo qi) {
-		return mailStore.get(qi.getMailid());
-	}
-	
-	public void remove(String messageName) {
-		synchronized (mailingLock) {
-			mailStore.remove(messageName);
-			queueStore.remove(messageName);
-		}
-	}
-	
-	@Override
-	public void run() {
-		running = true;
-		AspirinInternal.getLogger().info("DeliveryManager started.");
-		while( running )
-		{
-			QueueInfo qi = null;
-			try {
-				qi = queueStore.next();
-				if( qi != null )
-				{
-					MimeMessage message = get(qi);
-					if( message == null )
-					{
-						AspirinInternal.getLogger().warn("No MimeMessage found for qi={}",qi);
-						qi.setResultInfo("No MimeMessage found.");
-						qi.setState(DeliveryState.FAILED);
-						release(qi);
-						continue;
-					}
-					DeliveryContext dCtx = new DeliveryContext()
-						.setQueueInfo(qi)
-						.setMessage(message);
-					AspirinInternal.getLogger().trace("DeliveryManager.run(): Pool state. A{}/I{}",new Object[]{deliveryThreadObjectPool.getNumActive(),deliveryThreadObjectPool.getNumIdle()});
-					try 
-					{
-						AspirinInternal.getLogger().debug("DeliveryManager.run(): Start delivery. qi={}",qi);
-						DeliveryThread dThread = (DeliveryThread)deliveryThreadObjectPool.borrowObject();
-						AspirinInternal.getLogger().trace("DeliveryManager.run(): Borrow DeliveryThread object. dt={}: state '{}/{}'",new Object[]{dThread.getName(), dThread.getState().name(), dThread.isAlive()});
-						dThread.setContext(dCtx);
-						/*
-						 * On first borrow the DeliveryThread is created and 
-						 * initialized, but not started, because the first 
-						 * time we have to set up the QueItem to deliver.
-						 */
-						if( !dThread.isAlive() )
-							dThread.start();
-					} catch ( IllegalStateException ise )
-					{
-						/*
-						 * This could be happen, if thread is running, but 
-						 * ObjectPool is already closed. It is a normal process 
-						 * of Aspirin sending thread shutdown.
-						 */
-						release(qi);
-					} catch ( NoSuchElementException nsee )
-					{
-						/*
-						 * This happens if there is a lot of mail to send, and 
-						 * no idle DeliveryThread is available.
-						 */
-						AspirinInternal.getLogger().debug("DeliveryManager.run(): No idle DeliveryThread is available: {}",nsee.getMessage());
-						release(qi);
-					} catch ( Exception e )
-					{
-						AspirinInternal.getLogger().error("DeliveryManager.run(): Failed borrow delivery thread object.",e);
-						release(qi);
-					}
-				}
-				else
-				{
-					if( AspirinInternal.getLogger().isTraceEnabled() && 0 < queueStore.size() )
-						AspirinInternal.getLogger().trace("DeliveryManager.run(): There is no sendable item in the queue. Fallback to waiting state for a minute.");
-					synchronized (this) {
-						try
-						{
-							/*
-							 * We should wait for a specified time, because 
-							 * some emails unsent could be sendable again.
-							 */
-							wait(60000);
-						}catch (InterruptedException e)
-						{
-							running = false;
-						}
-					}
-				}
-				
-			} catch (Throwable t) {
-				if( qi != null )
-					release(qi);
-			}
-			
-		}
-		AspirinInternal.getLogger().info("DeliveryManager terminated.");
-	}
-	
-	public boolean isRunning() {
-		return running;
-	}
-	
-	public void terminate() {
-		running = false;
-	}
-	
-	public void release(QueueInfo qi) {
-		if( qi.hasState(DeliveryState.IN_PROGRESS) )
-		{
-			if( qi.isInTimeBounds() )
-			{
-				qi.setState(DeliveryState.QUEUED);
-				AspirinInternal.getLogger().trace("DeliveryManager.release(): Releasing: QUEUED. qi={}",qi);
-			}
-			else
-			{
-				qi.setState(DeliveryState.FAILED);
-				AspirinInternal.getLogger().trace("DeliveryManager.release(): Releasing: FAILED. qi={}",qi);
-			}
-		}
-		queueStore.setSendingResult(qi);
-		if( queueStore.isCompleted(qi.getMailid()) )
-			queueStore.remove(qi.getMailid());
-		AspirinInternal.getLogger().trace("DeliveryManager.release(): Release item '{}' with state: '{}' after {} attempts.",new Object[]{qi.getMailid(),qi.getState().name(), qi.getAttemptCount()});
-	}
-	
-	public boolean isCompleted(QueueInfo qi) {
-		return queueStore.isCompleted(qi.getMailid());
-	}
-	
-	@Override
-	public void configChanged(String parameterName) {
-		synchronized (mailingLock) {
-			if( parameterName.equals(Configuration.PARAM_MAILSTORE_CLASS) )
-				mailStore = AspirinInternal.getConfiguration().getMailStore();
-			else
-			if( parameterName.equals(Configuration.PARAM_QUEUESTORE_CLASS) )
-				queueStore = AspirinInternal.getConfiguration().getQueueStore();
-			if( parameterName.equals(ConfigurationMBean.PARAM_DELIVERY_THREADS_ACTIVE_MAX) )
-				((GenericObjectPool)deliveryThreadObjectPool).setMaxActive(AspirinInternal.getConfiguration().getDeliveryThreadsActiveMax());
-			else
-			if( parameterName.equals(ConfigurationMBean.PARAM_DELIVERY_THREADS_IDLE_MAX) )
-				((GenericObjectPool)deliveryThreadObjectPool).setMaxIdle(AspirinInternal.getConfiguration().getDeliveryThreadsIdleMax());
-		}
-	}
-	
-	public DeliveryHandler getDeliveryHandler(String handlerName) {
-		return deliveryHandlers.get(handlerName);
-	}
-	
-	public void shutdown() {
-		this.running = false;
-		try {
-			deliveryThreadObjectPool.close();
-			deliveryThreadObjectPool.clear();
-		} catch (Exception e) {
-			AspirinInternal.getLogger().error("DeliveryManager.shutdown() failed.",e);
-		}
-		maintenanceThread.shutdown();
-	}
+    @Nullable
+    private final DeliveryMaintenanceThread maintenanceThread;
+    @NotNull
+    private final Object mailingLock = new Object();
+    @Nullable
+    private final ObjectPool deliveryThreadObjectPool;
+    @NotNull
+    private final Map<String, DeliveryHandler> deliveryHandlers = new HashMap<>();
+    @Nullable
+    private MailStore mailStore;
+    @Nullable
+    private QueueStore queueStore;
+    private boolean running;
 
+    public DeliveryManager() {
+        // Set up default objects.
+        setName("Aspirin-" + getClass().getSimpleName() + "-" + getId());
+
+        // Configure pool of DeliveryThread threads
+        GenericObjectPool.Config gopConf = new GenericObjectPool.Config();
+        gopConf.lifo = false;
+        gopConf.maxActive = AspirinInternal.getConfiguration().getDeliveryThreadsActiveMax();
+        gopConf.maxIdle = AspirinInternal.getConfiguration().getDeliveryThreadsIdleMax();
+        gopConf.maxWait = 5000L;
+        gopConf.testOnReturn = true;
+        gopConf.whenExhaustedAction = GenericObjectPool.WHEN_EXHAUSTED_BLOCK;
+
+        // Create DeliveryThread object factory used in pool
+        GenericPoolableDeliveryThreadFactory threadFactory = new GenericPoolableDeliveryThreadFactory();
+
+        // Create pool
+        deliveryThreadObjectPool = new GenericObjectPool(threadFactory, gopConf);
+
+        // Initialize object factory of pool
+        threadFactory.init(new ThreadGroup("DeliveryThreadGroup"), deliveryThreadObjectPool);
+
+        // Set up stores and configuration listener
+        queueStore = AspirinInternal.getConfiguration().getQueueStore();
+        queueStore.init();
+
+        mailStore = AspirinInternal.getConfiguration().getMailStore();
+        mailStore.init();
+
+        maintenanceThread = new DeliveryMaintenanceThread();
+        maintenanceThread.start();
+
+        // Set up deliveryhandlers
+        // TODO create by configuration
+        deliveryHandlers.put(SendMessage.class.getCanonicalName(), new SendMessage());
+        deliveryHandlers.put(ResolveHost.class.getCanonicalName(), new ResolveHost());
+
+        AspirinInternal.getConfiguration().addListener(this);
+    }
+
+    @NotNull
+    public String add(@NotNull MimeMessage mimeMessage) throws MessagingException {
+        Objects.requireNonNull(mimeMessage, "mimeMessage");
+        String mailid = AspirinInternal.getMailID(mimeMessage);
+        long expiry = AspirinInternal.getExpiry(mimeMessage);
+        Collection<InternetAddress> recipients = AspirinInternal.extractRecipients(mimeMessage);
+        synchronized (mailingLock) {
+            mailStore.set(mailid, mimeMessage);
+            queueStore.add(mailid, expiry, recipients);
+        }
+        return mailid;
+    }
+
+    @Nullable
+    public MimeMessage get(@NotNull QueueInfo qi) {
+        Objects.requireNonNull(qi, "qi");
+        return mailStore.get(qi.getMailid());
+    }
+
+    public void remove(@NotNull String messageName) {
+        Objects.requireNonNull(messageName, "messageName");
+
+        synchronized (mailingLock) {
+            mailStore.remove(messageName);
+            queueStore.remove(messageName);
+        }
+    }
+
+    @Override
+    public void run() {
+        running = true;
+        AspirinInternal.getLogger().info("DeliveryManager started.");
+
+        while (running) {
+            QueueInfo qi = null;
+
+            try {
+                qi = queueStore.next();
+
+                if (qi != null) {
+                    MimeMessage message = get(qi);
+
+                    if (message == null) {
+                        AspirinInternal.getLogger().warn("No MimeMessage found for qi={}", qi);
+                        qi.setResultInfo("No MimeMessage found.");
+                        qi.setState(DeliveryState.FAILED);
+                        release(qi);
+                        continue;
+                    }
+
+                    DeliveryContext dCtx = new DeliveryContext()
+                            .setQueueInfo(qi)
+                            .setMessage(message);
+
+                    AspirinInternal.getLogger().trace(
+                            "DeliveryManager.run(): Pool state. A{}/I{}",
+                            deliveryThreadObjectPool.getNumActive(),
+                            deliveryThreadObjectPool.getNumIdle());
+
+                    try {
+                        AspirinInternal.getLogger().debug("DeliveryManager.run(): Start delivery. qi={}", qi);
+                        DeliveryThread dThread = (DeliveryThread) deliveryThreadObjectPool.borrowObject();
+
+                        AspirinInternal.getLogger().trace(
+                                "DeliveryManager.run(): Borrow DeliveryThread object. dt={}: state '{}/{}'",
+                                new Object[]{dThread.getName(), dThread.getState().name(), dThread.isAlive()});
+
+                        dThread.setContext(dCtx);
+                        /*
+                         * On first borrow the DeliveryThread is created and
+                         * initialized, but not started, because the first
+                         * time we have to set up the QueItem to deliver.
+                         */
+                        if (!dThread.isAlive())
+                            dThread.start();
+                    } catch (IllegalStateException ise) {
+                        /*
+                         * This could be happen, if thread is running, but
+                         * ObjectPool is already closed. It is a normal process
+                         * of Aspirin sending thread shutdown.
+                         */
+                        release(qi);
+                    } catch (NoSuchElementException nsee) {
+                        /*
+                         * This happens if there is a lot of mail to send, and
+                         * no idle DeliveryThread is available.
+                         */
+                        AspirinInternal.getLogger().debug("DeliveryManager.run(): No idle DeliveryThread is available: {}", nsee.getMessage());
+                        release(qi);
+                    } catch (Exception e) {
+                        AspirinInternal.getLogger().error("DeliveryManager.run(): Failed borrow delivery thread object.", e);
+                        release(qi);
+                    }
+                } else {
+                    if (AspirinInternal.getLogger().isTraceEnabled() && 0 < queueStore.size())
+                        AspirinInternal.getLogger().trace("DeliveryManager.run(): There is no sendable item in the queue. Fallback to waiting state for a minute.");
+                    synchronized (this) {
+                        try {
+                            /*
+                             * We should wait for a specified time, because
+                             * some emails unsent could be sendable again.
+                             */
+                            wait(60000L);
+                        } catch (InterruptedException e) {
+                            running = false;
+                        }
+                    }
+                }
+
+            } catch (UnsupportedOperationException t) {
+                if (qi != null)
+                    release(qi);
+            }
+
+        }
+        AspirinInternal.getLogger().info("DeliveryManager terminated.");
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public void terminate() {
+        running = false;
+    }
+
+    public void release(@NotNull QueueInfo qi) {
+        Objects.requireNonNull(qi, "qi");
+
+        if (qi.hasState(DeliveryState.IN_PROGRESS)) {
+            if (qi.isInTimeBounds()) {
+                qi.setState(DeliveryState.QUEUED);
+                AspirinInternal.getLogger().trace("DeliveryManager.release(): Releasing: QUEUED. qi={}", qi);
+            } else {
+                qi.setState(DeliveryState.FAILED);
+                AspirinInternal.getLogger().trace("DeliveryManager.release(): Releasing: FAILED. qi={}", qi);
+            }
+        }
+
+        queueStore.setSendingResult(qi);
+        if (queueStore.isCompleted(qi.getMailid())) queueStore.remove(qi.getMailid());
+
+        AspirinInternal.getLogger().trace(
+                "DeliveryManager.release(): Release item '{}' with state: '{}' after {} attempts.",
+                new Object[]{qi.getMailid(), qi.getState().name(), qi.getAttemptCount()});
+    }
+
+    public boolean isCompleted(@NotNull QueueInfo qi) {
+        Objects.requireNonNull(qi, "qi");
+        return queueStore.isCompleted(qi.getMailid());
+    }
+
+    @Override
+    public void configChanged(@NotNull String parameterName) {
+        Objects.requireNonNull(parameterName, "parameterName");
+        synchronized (mailingLock) {
+            if (parameterName.equals(ConfigurationMBean.PARAM_MAILSTORE_CLASS))
+                mailStore = AspirinInternal.getConfiguration().getMailStore();
+            else if (parameterName.equals(ConfigurationMBean.PARAM_QUEUESTORE_CLASS))
+                queueStore = AspirinInternal.getConfiguration().getQueueStore();
+            if (parameterName.equals(ConfigurationMBean.PARAM_DELIVERY_THREADS_ACTIVE_MAX))
+                ((GenericObjectPool) deliveryThreadObjectPool).setMaxActive(AspirinInternal.getConfiguration().getDeliveryThreadsActiveMax());
+            else if (parameterName.equals(ConfigurationMBean.PARAM_DELIVERY_THREADS_IDLE_MAX))
+                ((GenericObjectPool) deliveryThreadObjectPool).setMaxIdle(AspirinInternal.getConfiguration().getDeliveryThreadsIdleMax());
+        }
+    }
+
+    @Nullable
+    public DeliveryHandler getDeliveryHandler(@NotNull String handlerName) {
+        Objects.requireNonNull(handlerName);
+        return deliveryHandlers.get(handlerName);
+    }
+
+    public void shutdown() {
+        running = false;
+        try {
+            deliveryThreadObjectPool.close();
+            deliveryThreadObjectPool.clear();
+        } catch (Exception e) {
+            AspirinInternal.getLogger().error("DeliveryManager.shutdown() failed.", e);
+        }
+        maintenanceThread.shutdown();
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryThread.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/DeliveryThread.java
@@ -1,175 +1,180 @@
 package org.masukomi.aspirin.core.delivery;
 
-import javax.mail.MessagingException;
-import javax.mail.Session;
-
 import org.apache.commons.pool.ObjectPool;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.masukomi.aspirin.core.AspirinInternal;
 import org.masukomi.aspirin.core.dns.ResolveHost;
 import org.masukomi.aspirin.core.store.queue.DeliveryState;
 import org.masukomi.aspirin.core.store.queue.QueueInfo;
 
+import javax.mail.MessagingException;
+
 /**
  * Based on original RemoteDelivery class.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public class DeliveryThread extends Thread {
-	
-	private boolean running = true;
-	private ObjectPool parentObjectPool = null;
-	private DeliveryContext dCtx = null;
-	
-	DeliveryThread(ThreadGroup parentThreadGroup) {
-		super(parentThreadGroup, DeliveryThread.class.getSimpleName());
-	}
-	
-	public ObjectPool getParentObjectPool() {
-		return parentObjectPool;
-	}
-	public void setParentObjectPool(ObjectPool parentObjectPool) {
-		this.parentObjectPool = parentObjectPool;
-	}
-	
-	public void shutdown() {
-		AspirinInternal.getLogger().debug("DeliveryThread ({}).shutdown(): Called.",getName());
-		running = false;
-		synchronized (this) {
-			notify();
-		}
-	}
-	
-	@Override
-	public void run() {
-		while (running) {
-			synchronized (this) {
-				if( dCtx == null )
-				{
-					// Wait for next QueueInfo to deliver 
-					try
-					{
-						if( running )
-						{
-							AspirinInternal.getLogger().trace("DeliveryThread ({}).run(): Wait for next sendable item.",getName());
-							wait(60000);
-							continue;
-						}
-					} catch (InterruptedException ie)
-					/*
-					 * On interrupt we shutdown this thread and remove from 
-					 * pool. It could be a QueueInfo in the qi variable, so we 
-					 * try to release it before finish the work.
-					 */
-					{
-						if( dCtx != null )
-						{
-							AspirinInternal.getLogger().trace("DeliveryThread ({}).run(): Release item after interruption. qi={}", new Object[]{getName(),dCtx});
-							AspirinInternal.getDeliveryManager().release(dCtx.getQueueInfo());
-							dCtx = null;
-						}
-						running = false;
-						try
-						{
-							AspirinInternal.getLogger().trace("DeliveryThread ({}).run(): Invalidate DeliveryThread object in the pool.",getName());
-							parentObjectPool.invalidateObject(this);
-						}catch (Exception e)
-						{
-							throw new RuntimeException("The object could not be invalidated in the pool.",e);
-						}
-					}
 
-				}
-			}
-			// Try to deliver the QueueInfo
-			try
-			{
-				if( dCtx != null )
-				{
-					AspirinInternal.getLogger().trace("DeliveryThread ({}).run(): Call delivering... dCtx={}",new Object[]{getName(),dCtx});
-					deliver(dCtx, AspirinInternal.getConfiguration().getMailSession());
-					AspirinInternal.getDeliveryManager().release(dCtx.getQueueInfo());
-					dCtx = null;
-				}
-			}catch (Exception e)
-			{
-				AspirinInternal.getLogger().error("DeliveryThread ("+getName()+").run(): Could not deliver message. dCtx={"+dCtx+"}", e);
-			}finally
-			/*
-			 * Sometimes QueueInfo's status could be IN_PROCESS. This QueueInfo 
-			 * have to be released before we finishing this round of running. 
-			 * After releasing the dCtx variable will be nullified.
-			 */
-			{
-				if( dCtx != null && !dCtx.getQueueInfo().isSendable() )
-				{
-					AspirinInternal.getDeliveryManager().release(dCtx.getQueueInfo());
-					dCtx = null;
-				}
-			}
-			if( dCtx == null )
-			{
-				try
-				{
-					AspirinInternal.getLogger().trace("DeliveryThread ({}).run(): Try to give back DeliveryThread object into the pool.",getName());
-					parentObjectPool.returnObject(this);
-				}catch (Exception e)
-				{
-					AspirinInternal.getLogger().error("DeliveryThread ("+getName()+").run(): The object could not be returned into the pool.",e);
-					this.shutdown();
-				}
-			}
-		}
-	}
-	
-	public void setContext(DeliveryContext dCtx) throws MessagingException {
-		/*
-		 * If the dCtx variable is not null, then the previous item could be in. 
-		 * If the previous item is not ready to send and is not completed, we 
-		 * have to try send this item with this thread. After this thread is 
-		 * waked up, there were thrown an Exception.
-		 */
-		synchronized (this) {
-			if( this.dCtx != null )
-			{
-				if( this.dCtx.getQueueInfo().hasState(org.masukomi.aspirin.core.store.queue.DeliveryState.IN_PROGRESS) )
-					notify();
-				throw new MessagingException("The previous QuedItem was not removed from this thread.");
-			}
-			this.dCtx = dCtx;
-			AspirinInternal.getLogger().trace("DeliveryThread ({}).setQuedItem(): Item was set. qi={}",new Object[]{getName(),dCtx});
-			notify();
-		}
-	}
-	
-	private void deliver(DeliveryContext dCtx, Session session) {
-		AspirinInternal.getLogger().info("DeliveryThread ({}).deliver(): Starting mail delivery. qi={}", new Object[]{getName(),dCtx});
-		String[] handlerList = new String[]{
-				ResolveHost.class.getCanonicalName(),
-				SendMessage.class.getCanonicalName()
-		};
-		QueueInfo qInfo = dCtx.getQueueInfo();
-		for( String handlerName : handlerList )
-		{
-			try {
-				AspirinInternal.getDeliveryManager().getDeliveryHandler(handlerName).handle(dCtx);
-			} catch (DeliveryException de) {
-				qInfo.setResultInfo(de.getMessage());
-				AspirinInternal.getLogger().info("DeliveryThread ({}).deliver(): Mail delivery failed: {}. qi={}", new Object[]{getName(),qInfo.getResultInfo(),dCtx});
-				if( de.isPermanent() )
-					qInfo.setState(DeliveryState.FAILED);
-				else
-					qInfo.setState(DeliveryState.QUEUED);
-				return;
-			}
-		}
-		if( qInfo.hasState(DeliveryState.IN_PROGRESS) )
-		{
-			if( qInfo.getResultInfo() == null )
-				qInfo.setResultInfo("250 OK");
-			AspirinInternal.getLogger().info("DeliveryThread ({}).deliver(): Mail delivery success: {}. qi={}", new Object[]{getName(),qInfo.getResultInfo(),dCtx});
-			qInfo.setState(DeliveryState.SENT);
-		}
-	}
+    private boolean running = true;
+    private ObjectPool parentObjectPool;
+    @Nullable
+    private DeliveryContext dCtx;
+
+    DeliveryThread(@Nullable ThreadGroup parentThreadGroup) {
+        super(parentThreadGroup, DeliveryThread.class.getSimpleName());
+    }
+
+    public ObjectPool getParentObjectPool() {
+        return parentObjectPool;
+    }
+
+    public void setParentObjectPool(ObjectPool parentObjectPool) {
+        this.parentObjectPool = parentObjectPool;
+    }
+
+    public void shutdown() {
+        AspirinInternal.getLogger().debug("DeliveryThread ({}).shutdown(): Called.", getName());
+        running = false;
+        synchronized (this) {
+            notifyAll();
+        }
+    }
+
+    @Override
+    public void run() {
+        while (running) {
+            synchronized (this) {
+                if (dCtx == null) {
+                    // Wait for next QueueInfo to deliver
+                    try {
+                        if (running) {
+                            AspirinInternal.getLogger().trace("DeliveryThread ({}).run(): Wait for next sendable item.", getName());
+                            wait(60000);
+                            continue;
+                        }
+                    } catch (InterruptedException ie)
+                        /*
+                         * On interrupt we shutdown this thread and remove from
+                         * pool. It could be a QueueInfo in the qi variable, so we
+                         * try to release it before finish the work.
+                         */ {
+                        if (dCtx != null) {
+                            AspirinInternal.getLogger().trace(
+                                    "DeliveryThread ({}).run(): Release item after interruption. qi={}",
+                                    getName(),
+                                    dCtx);
+
+                            AspirinInternal.getDeliveryManager().release(dCtx.getQueueInfo());
+                            dCtx = null;
+                        }
+                        running = false;
+                        try {
+                            AspirinInternal.getLogger().trace("DeliveryThread ({}).run(): Invalidate DeliveryThread object in the pool.", getName());
+                            parentObjectPool.invalidateObject(this);
+                        } catch (Exception e) {
+                            throw new IllegalStateException("The object could not be invalidated in the pool.", e);
+                        }
+                    }
+
+                }
+            }
+            // Try to deliver the QueueInfo
+            try {
+                if (dCtx != null) {
+                    AspirinInternal.getLogger().trace(
+                            "DeliveryThread ({}).run(): Call delivering... dCtx={}",
+                            getName(),
+                            dCtx);
+
+                    deliver(dCtx);
+                    AspirinInternal.getDeliveryManager().release(dCtx.getQueueInfo());
+                    dCtx = null;
+                }
+            } catch (Exception e) {
+                AspirinInternal.getLogger().error("DeliveryThread (" + getName() + ").run(): Could not deliver message. dCtx={" + dCtx + "}", e);
+            } finally
+                /*
+                 * Sometimes QueueInfo's status could be IN_PROCESS. This QueueInfo
+                 * have to be released before we finishing this round of running.
+                 * After releasing the dCtx variable will be nullified.
+                 */ {
+                if (dCtx != null && !dCtx.getQueueInfo().isSendable()) {
+                    AspirinInternal.getDeliveryManager().release(dCtx.getQueueInfo());
+                    dCtx = null;
+                }
+            }
+            if (dCtx == null) {
+                try {
+                    AspirinInternal.getLogger().trace("DeliveryThread ({}).run(): Try to give back DeliveryThread object into the pool.", getName());
+                    parentObjectPool.returnObject(this);
+                } catch (Exception e) {
+                    AspirinInternal.getLogger().error("DeliveryThread (" + getName() + ").run(): The object could not be returned into the pool.", e);
+                    shutdown();
+                }
+            }
+        }
+    }
+
+    public synchronized void setContext(@Nullable DeliveryContext dCtx) throws MessagingException {
+        /*
+         * If the dCtx variable is not null, then the previous item could be in.
+         * If the previous item is not ready to send and is not completed, we
+         * have to try send this item with this thread. After this thread is
+         * waked up, there were thrown an Exception.
+         */
+        if (this.dCtx != null) {
+            if (this.dCtx.getQueueInfo().hasState(DeliveryState.IN_PROGRESS))
+                notifyAll();
+            throw new MessagingException("The previous QuedItem was not removed from this thread.");
+        }
+
+        this.dCtx = dCtx;
+        AspirinInternal.getLogger().trace("DeliveryThread ({}).setQuedItem(): Item was set. qi={}", getName(), dCtx);
+        notifyAll();
+    }
+
+    private void deliver(@NotNull DeliveryContext dCtx) {
+        AspirinInternal.getLogger().info(
+                "DeliveryThread ({}).deliver(): Starting mail delivery. qi={}",
+                getName(),
+                dCtx);
+
+        QueueInfo qInfo = dCtx.getQueueInfo();
+
+        for (String handlerName : new String[]{
+                ResolveHost.class.getCanonicalName(),
+                SendMessage.class.getCanonicalName()
+        }) {
+            try {
+                AspirinInternal.getDeliveryManager().getDeliveryHandler(handlerName).handle(dCtx);
+            } catch (DeliveryException de) {
+                qInfo.setResultInfo(de.getMessage());
+
+                AspirinInternal.getLogger().info(
+                        "DeliveryThread ({}).deliver(): Mail delivery failed: {}. qi={}",
+                        new Object[]{getName(), qInfo.getResultInfo(), dCtx});
+
+                if (de.isPermanent())
+                    qInfo.setState(DeliveryState.FAILED);
+                else
+                    qInfo.setState(DeliveryState.QUEUED);
+
+                return;
+            }
+        }
+
+        if (qInfo.hasState(DeliveryState.IN_PROGRESS)) {
+            if (qInfo.getResultInfo() == null)
+                qInfo.setResultInfo("250 OK");
+
+            AspirinInternal.getLogger().info(
+                    "DeliveryThread ({}).deliver(): Mail delivery success: {}. qi={}",
+                    new Object[]{getName(), qInfo.getResultInfo(), dCtx});
+
+            qInfo.setState(DeliveryState.SENT);
+        }
+    }
 
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/GenericPoolableDeliveryThreadFactory.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/GenericPoolableDeliveryThreadFactory.java
@@ -1,9 +1,9 @@
 package org.masukomi.aspirin.core.delivery;
 
-import java.lang.Thread.State;
-
 import org.apache.commons.pool.BasePoolableObjectFactory;
 import org.apache.commons.pool.ObjectPool;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.masukomi.aspirin.core.AspirinInternal;
 
 /**
@@ -11,75 +11,81 @@ import org.masukomi.aspirin.core.AspirinInternal;
  * </p>
  *
  * @author Laszlo Solova
- *
  */
 public class GenericPoolableDeliveryThreadFactory extends BasePoolableObjectFactory {
-	
-	/**
-	 * This is the ThreadGroup of DeliveryThread objects. On shutdown it is 
-	 * easier to close all DeliveryThread threads with usage of this group.
-	 */
-	private ThreadGroup deliveryThreadGroup = null;
-	private ObjectPool myParentPool = null;
-	
-	/**
-	 * This is the counter of created DeliveryThread thread objects.
-	 */
-	private Integer rdCount = 0;
-	private Object rdLock = new Object();
-	
-	/**
-	 * <p>Initialization of this Factory. Prerequisite of right working.</p>
-	 * 
-	 * @param deliveryThreadGroup The threadgroup which contains the 
-	 * DeliveryThread threads.
-	 * @param pool The pool which use this factory to create and handle objects.
-	 */
-	public void init(ThreadGroup deliveryThreadGroup, ObjectPool pool) {
-		this.deliveryThreadGroup = deliveryThreadGroup;
-		myParentPool = pool;
-	}
-	
-	@Override
-	public Object makeObject() throws Exception {
-		if( myParentPool == null )
-			throw new RuntimeException("Please set the parent pool for right working.");
-		DeliveryThread dThread = new DeliveryThread(deliveryThreadGroup);
-		synchronized (rdLock) {
-			rdCount++;
-			dThread.setName(DeliveryThread.class.getSimpleName()+"-"+rdCount);
-		}
-		dThread.setParentObjectPool(myParentPool);
-		AspirinInternal.getConfiguration().getLogger().trace("GenericPoolableDeliveryThreadFactory.makeObject(): New DeliveryThread object created: {}.",dThread.getName());
-		return dThread;
-	}
-	
-	@Override
-	public void destroyObject(Object obj) throws Exception {
-		if( obj instanceof DeliveryThread )
-		{
-			DeliveryThread dThread = (DeliveryThread)obj;
-			AspirinInternal.getConfiguration().getLogger().trace(getClass().getSimpleName()+".destroyObject(): destroy thread {}.",dThread.getName());
-			dThread.shutdown();
-		}
-	}
+    @NotNull
+    private final Object rdLock = new Object();
+    /**
+     * This is the ThreadGroup of DeliveryThread objects. On shutdown it is
+     * easier to close all DeliveryThread threads with usage of this group.
+     */
+    @Nullable
+    private ThreadGroup deliveryThreadGroup;
+    @Nullable
+    private ObjectPool myParentPool;
+    /**
+     * This is the counter of created DeliveryThread thread objects.
+     */
+    private int rdCount;
 
-	@Override
-	public boolean validateObject(Object obj) {
-		if( obj instanceof DeliveryThread )
-		{
-			DeliveryThread dThread = (DeliveryThread)obj;
-			return
-				dThread.isAlive() &&
-				(
-					dThread.getState().equals(State.NEW) ||
-					dThread.getState().equals(State.RUNNABLE) ||
-					dThread.getState().equals(State.TIMED_WAITING) ||
-					dThread.getState().equals(State.WAITING)
-				)
-			;
-		}
-		return false;
-	}
+    /**
+     * <p>Initialization of this Factory. Prerequisite of right working.</p>
+     *
+     * @param deliveryThreadGroup The threadgroup which contains the
+     *                            DeliveryThread threads.
+     * @param pool                The pool which use this factory to create and handle objects.
+     */
+    public void init(@Nullable ThreadGroup deliveryThreadGroup, @Nullable ObjectPool pool) {
+        this.deliveryThreadGroup = deliveryThreadGroup;
+        myParentPool = pool;
+    }
 
+    @Override
+    @NotNull
+    public Object makeObject() {
+        if (myParentPool == null)
+            throw new IllegalStateException("Please set the parent pool for right working.");
+
+        DeliveryThread dThread = new DeliveryThread(deliveryThreadGroup);
+
+        synchronized (rdLock) {
+            rdCount++;
+            dThread.setName(DeliveryThread.class.getSimpleName() + "-" + rdCount);
+        }
+
+        dThread.setParentObjectPool(myParentPool);
+
+        AspirinInternal.getConfiguration()
+                .getLogger()
+                .trace("GenericPoolableDeliveryThreadFactory.makeObject(): New DeliveryThread object created: {}.",
+                        dThread.getName());
+
+        return dThread;
+    }
+
+    @Override
+    public void destroyObject(@Nullable Object obj) {
+        if (obj instanceof DeliveryThread) {
+            DeliveryThread dThread = (DeliveryThread) obj;
+
+            AspirinInternal.getConfiguration()
+                    .getLogger()
+                    .trace(getClass().getSimpleName() + ".destroyObject(): destroy thread {}.", dThread.getName());
+
+            dThread.shutdown();
+        }
+    }
+
+    @Override
+    public boolean validateObject(@Nullable Object obj) {
+        if (obj instanceof DeliveryThread) {
+            DeliveryThread dThread = (DeliveryThread) obj;
+
+            return dThread.isAlive() && (dThread.getState() == Thread.State.NEW ||
+                    dThread.getState() == Thread.State.RUNNABLE || dThread.getState() == Thread.State.TIMED_WAITING ||
+                    dThread.getState() == Thread.State.WAITING);
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/SendMessage.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/SendMessage.java
@@ -1,9 +1,9 @@
 package org.masukomi.aspirin.core.delivery;
 
-import java.net.ConnectException;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Properties;
+import com.sun.mail.smtp.SMTPTransport;
+import org.jetbrains.annotations.NotNull;
+import org.masukomi.aspirin.core.AspirinInternal;
+import org.masukomi.aspirin.core.store.queue.DeliveryState;
 
 import javax.mail.MessagingException;
 import javax.mail.Session;
@@ -12,111 +12,115 @@ import javax.mail.URLName;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-
-import org.masukomi.aspirin.core.AspirinInternal;
-import org.masukomi.aspirin.core.store.queue.DeliveryState;
-
-import com.sun.mail.smtp.SMTPTransport;
+import java.net.ConnectException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Properties;
 
 /**
- * 
  * @author Laszlo Solova
- *
  */
 public class SendMessage implements DeliveryHandler {
+    @NotNull
+    private static Exception resolveException(@NotNull MessagingException msgExc) {
+        Objects.requireNonNull(msgExc, "msgExc");
+        MessagingException me = msgExc;
+        Exception nextException;
+        Exception lastException = msgExc;
+        while ((nextException = me.getNextException()) != null) {
+            lastException = nextException;
+            if (MessagingException.class.getCanonicalName().equals(nextException.getClass().getCanonicalName()))
+                me = (MessagingException) nextException;
+            else
+                break;
+        }
+        return lastException;
+    }
 
-	@Override
-	public void handle(DeliveryContext dCtx) throws DeliveryException {
-		// Collect sending informations
-		Collection<URLName> targetServers = dCtx.getContextVariable("targetservers");
-		Session session = AspirinInternal.getConfiguration().getMailSession();
-		MimeMessage message = dCtx.getMessage();
-		
-		// Prepare and send
-		Iterator<URLName> urlnIt = targetServers.iterator();
-		InternetAddress[] addr;
-		try {
-			addr = new InternetAddress[]{new InternetAddress(dCtx.getQueueInfo().getRecipient())};
-		} catch (AddressException e) {
-			throw new DeliveryException("Recipient could not be parsed:"+dCtx.getQueueInfo().getRecipient(), true, e);
-		}
-		boolean sentSuccessfully = false;
-		while ( !sentSuccessfully && urlnIt.hasNext() )
-		{
-			try {
-				URLName outgoingMailServer = urlnIt.next();
-				AspirinInternal.getLogger().debug("SendMessage.handle(): Attempting delivery of '{}' to recipient '{}' on host '{}' ",new Object[]{dCtx.getQueueInfo().getMailid(),dCtx.getQueueInfo().getRecipient(),outgoingMailServer});
-				Properties props = session.getProperties();
-				if (message.getSender() == null) {
-					props.put("mail.smtp.from", "<>");
-				} else {
-					String sender = message.getSender().toString();
-					props.put("mail.smtp.from", sender);
-				}
-				Transport transport = null;
- 				try {
-					transport = session.getTransport(outgoingMailServer);
-					try {
-						transport.connect();
-						transport.sendMessage(message, addr);
-						if( transport instanceof SMTPTransport )
-						{
-							String response = ((SMTPTransport)transport).getLastServerResponse();
-							if( response != null )
-							{
-								AspirinInternal.getLogger().error("SendMessage.handle(): Last server response: {}.",response);
-								dCtx.getQueueInfo().setResultInfo(response);
-							}
-						}
-					} catch (MessagingException me) {
-						/* Catch on connection error only. */
-						if( resolveException(me) instanceof ConnectException )
-						{
-							AspirinInternal.getLogger().error("SendMessage.handle(): Connection failed.",me);
-							if( !urlnIt.hasNext() )
-								throw me;
-							else
-								continue;
-						}
-						else
-						{
-							throw me;
-						}
-					}
-					AspirinInternal.getLogger().debug("SendMessage.handle(): Mail '{}' sent successfully to '{}'.",new Object[]{dCtx.getQueueInfo().getMailid(),outgoingMailServer});
-					sentSuccessfully = true;
-					dCtx.addContextVariable("newstate", DeliveryState.SENT);
-				} finally {
-					if (transport != null) {
-						transport.close();
-						transport = null;
-					}
-				}
-			} catch (MessagingException me) {
-				String exMessage = resolveException(me).getMessage();
-				if( '5' == exMessage.charAt(0) )
-					throw new DeliveryException(exMessage, true);
-				else
-					throw new DeliveryException(exMessage, false);
-			} // end catch
-		} // end while
-		if( !sentSuccessfully )
-			throw new DeliveryException("SendMessage.handle(): Mail '{}' sending failed, try later.", false);
-	}
+    @Override
+    public void handle(@NotNull DeliveryContext dCtx) throws DeliveryException {
+        Objects.requireNonNull(dCtx, "dCtx");
+        // Collect sending information
+        Iterable<URLName> targetServers = dCtx.getContextVariable("targetservers");
+        Session session = AspirinInternal.getConfiguration().getMailSession();
+        MimeMessage message = dCtx.getMessage();
 
-	private Exception resolveException(MessagingException msgExc) {
-		MessagingException me = msgExc;
-		Exception nextException = null;
-		Exception lastException = msgExc;
-		while( (nextException = me.getNextException()) != null )
-		{
-			lastException = nextException;
-			if( MessagingException.class.getCanonicalName().equals(nextException.getClass().getCanonicalName()) )
-				me = (MessagingException)nextException;
-			else
-				break;
-		}
-		return lastException;
-	}
+        // Prepare and send
+        Iterator<URLName> urlnIt = targetServers.iterator();
+        InternetAddress[] addr;
 
+        try {
+            addr = new InternetAddress[]{new InternetAddress(dCtx.getQueueInfo().getRecipient())};
+        } catch (AddressException e) {
+            throw new DeliveryException("Recipient could not be parsed:" + dCtx.getQueueInfo().getRecipient(), true, e);
+        }
+
+        boolean sentSuccessfully = false;
+
+        while (!sentSuccessfully && urlnIt.hasNext()) {
+            try {
+                URLName outgoingMailServer = urlnIt.next();
+
+                AspirinInternal.getLogger().debug(
+                        "SendMessage.handle(): Attempting delivery of '{}' to recipient '{}' on host '{}' ",
+                        new Object[]{dCtx.getQueueInfo().getMailid(), dCtx.getQueueInfo().getRecipient(), outgoingMailServer});
+
+                Properties props = session.getProperties();
+
+                if (message.getSender() == null) props.setProperty("mail.smtp.from", "<>");
+                else {
+                    String sender = message.getSender().toString();
+                    props.setProperty("mail.smtp.from", sender);
+                }
+
+                Transport transport = null;
+
+                try {
+                    transport = session.getTransport(outgoingMailServer);
+                    try {
+                        transport.connect();
+                        transport.sendMessage(message, addr);
+
+                        if (transport instanceof SMTPTransport) {
+                            String response = ((SMTPTransport) transport).getLastServerResponse();
+
+                            if (response != null) {
+                                AspirinInternal.getLogger().error("SendMessage.handle(): Last server response: {}.", response);
+                                dCtx.getQueueInfo().setResultInfo(response);
+                            }
+                        }
+                    } catch (MessagingException me) {
+                        /* Catch on connection error only. */
+                        if (resolveException(me) instanceof ConnectException) {
+                            AspirinInternal.getLogger().error("SendMessage.handle(): Connection failed.", me);
+                            if (!urlnIt.hasNext())
+                                throw me;
+                            else
+                                continue;
+                        } else
+                            throw me;
+                    }
+
+                    AspirinInternal.getLogger().debug(
+                            "SendMessage.handle(): Mail '{}' sent successfully to '{}'.",
+                            dCtx.getQueueInfo().getMailid(), outgoingMailServer);
+
+                    sentSuccessfully = true;
+                    dCtx.addContextVariable("newstate", DeliveryState.SENT);
+                } finally {
+                    if (transport != null) transport.close();
+                }
+            } catch (MessagingException me) {
+                String exMessage = resolveException(me).getMessage();
+                if ('5' == exMessage.charAt(0))
+                    throw new DeliveryException(exMessage, true);
+                else
+                    throw new DeliveryException(exMessage, false);
+            }
+        }
+
+        if (!sentSuccessfully)
+            throw new DeliveryException("SendMessage.handle(): Mail '{}' sending failed, try later.", false);
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/delivery/SendMessage.java
+++ b/src/main/java/org/masukomi/aspirin/core/delivery/SendMessage.java
@@ -13,7 +13,6 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import java.net.ConnectException;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Properties;
@@ -113,10 +112,9 @@ public class SendMessage implements DeliveryHandler {
                 }
             } catch (MessagingException me) {
                 String exMessage = resolveException(me).getMessage();
-                if ('5' == exMessage.charAt(0))
-                    throw new DeliveryException(exMessage, true);
-                else
-                    throw new DeliveryException(exMessage, false);
+
+                if ('5' == exMessage.charAt(0)) throw new DeliveryException(exMessage, true);
+                else throw new DeliveryException(exMessage, false);
             }
         }
 

--- a/src/main/java/org/masukomi/aspirin/core/dns/DnsResolver.java
+++ b/src/main/java/org/masukomi/aspirin/core/dns/DnsResolver.java
@@ -42,6 +42,7 @@ public class DnsResolver {
     @NotNull
     public static List<URLName> getMXRecordsForHost(String hostName) {
         List<URLName> recordsColl = new Vector<>();
+
         try {
             boolean foundOriginalMX = true;
             Record[] records = new Lookup(hostName, Type.MX).run();
@@ -72,6 +73,7 @@ public class DnsResolver {
                 Arrays.sort(records, Comparator.comparingInt(arg0 -> ((MXRecord) arg0).getPriority()));
                 // Create records collection
                 recordsColl = new Vector<>(records.length);
+
                 for (Record record : records) {
                     MXRecord mx = (MXRecord) record;
                     String targetString = mx.getTarget().toString();
@@ -96,9 +98,9 @@ public class DnsResolver {
              */
             if (!foundOriginalMX) {
                 Record[] recordsTypeA = new Lookup(hostName, Type.A).run();
-                if (recordsTypeA != null && recordsTypeA.length > 0) {
+
+                if (recordsTypeA != null && recordsTypeA.length > 0)
                     recordsColl.add(0, new URLName(SMTP_PROTOCOL_PREFIX + hostName));
-                }
             }
 
         } catch (TextParseException e) {

--- a/src/main/java/org/masukomi/aspirin/core/dns/DnsResolver.java
+++ b/src/main/java/org/masukomi/aspirin/core/dns/DnsResolver.java
@@ -1,132 +1,110 @@
 package org.masukomi.aspirin.core.dns;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.masukomi.aspirin.core.AspirinInternal;
+import org.xbill.DNS.*;
 
 import javax.mail.URLName;
-
-import org.masukomi.aspirin.core.AspirinInternal;
-import org.xbill.DNS.Lookup;
-import org.xbill.DNS.MXRecord;
-import org.xbill.DNS.Record;
-import org.xbill.DNS.TextParseException;
-import org.xbill.DNS.Type;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Vector;
 
 /**
  * This object checks all DNS contents and get MX records for emails.
  * TODO Create DNS cache
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public class DnsResolver {
-	
-	public static final String SMTP_PROTOCOL_PREFIX = "smtp://";
-	
-	/**
-	 * <p>This method gives back the host name(s) where we can send the email. 
-	 * It is copied from it's original place in RemoteDelivery object.</p>
-	 * 
-	 * <p>First time we ask DNS to find MX record(s) of a domain name. If no MX 
-	 * records are found, we check the upper level domains (if exists). At last 
-	 * we try to get the domain A record, because the MX server could be same as 
-	 * the normal domain handler server. If only upper level domain has MX 
-	 * record then we append the A record of original hostname (if exists) as 
-	 * first element of record collection. If none of these tries are 
-	 * successful, we give back an empty collection.</p>
-	 * 
-	 * Special Thanks to Tim Motika (tmotika at ionami dot com) for 
-	 * his reworking of this method.
-	 * 
-	 * @param hostName We search the associated MX server of this hostname.
-	 * @return Collection of URLName objects. If no MX server found, then it 
-	 * gives back an empty collection.
-	 * 
-	 */
-	
-	public static Collection<URLName> getMXRecordsForHost(String hostName) {
+    @NotNull
+    public static final String SMTP_PROTOCOL_PREFIX = "smtp://";
 
-		Vector<URLName> recordsColl = null;
-		try {
-			boolean foundOriginalMX = true;
-			Record[] records = new Lookup(hostName, Type.MX).run();
-			
-			/*
-			 * Sometimes we should send an email to a subdomain which does not 
-			 * have own MX record and MX server. At this point we should find an 
-			 * upper level domain and server where we can deliver our email.
-			 *  
-			 * Example: subA.subB.domain.name has not own MX record and 
-			 * subB.domain.name is the mail exchange master of the subA domain 
-			 * too.
-			 */
-			if( records == null || records.length == 0 )
-			{
-				foundOriginalMX = false;
-				String upperLevelHostName = hostName;
-				while(		records == null &&
-							upperLevelHostName.indexOf(".") != upperLevelHostName.lastIndexOf(".") &&
-							upperLevelHostName.lastIndexOf(".") != -1
-					)
-				{
-					upperLevelHostName = upperLevelHostName.substring(upperLevelHostName.indexOf(".")+1);
-					records = new Lookup(upperLevelHostName, Type.MX).run();
-				}
-			}
+    /**
+     * <p>This method gives back the host name(s) where we can send the email.
+     * It is copied from it's original place in RemoteDelivery object.</p>
+     *
+     * <p>First time we ask DNS to find MX record(s) of a domain name. If no MX
+     * records are found, we check the upper level domains (if exists). At last
+     * we try to get the domain A record, because the MX server could be same as
+     * the normal domain handler server. If only upper level domain has MX
+     * record then we append the A record of original hostname (if exists) as
+     * first element of record collection. If none of these tries are
+     * successful, we give back an empty collection.</p>
+     * <p>
+     * Special Thanks to Tim Motika (tmotika at ionami dot com) for
+     * his reworking of this method.
+     *
+     * @param hostName We search the associated MX server of this hostname.
+     * @return Collection of URLName objects. If no MX server found, then it
+     * gives back an empty collection.
+     */
+    @NotNull
+    public static List<URLName> getMXRecordsForHost(String hostName) {
+        List<URLName> recordsColl = new Vector<>();
+        try {
+            boolean foundOriginalMX = true;
+            Record[] records = new Lookup(hostName, Type.MX).run();
 
-            if( records != null )
-            {
-            	// Sort in MX priority (higher number is lower priority)
-                Arrays.sort(records, new Comparator<Record>() {
-                    @Override
-                    public int compare(Record arg0, Record arg1) {
-                        return ((MXRecord)arg0).getPriority()-((MXRecord)arg1).getPriority();
-                    }
-                });
-                // Create records collection
-                recordsColl = new Vector<URLName>(records.length);
-                for (int i = 0; i < records.length; i++)
-				{ 
-					MXRecord mx = (MXRecord) records[i];
-					String targetString = mx.getTarget().toString();
-					URLName uName = new URLName(
-							SMTP_PROTOCOL_PREFIX +
-							targetString.substring(0, targetString.length() - 1)
-					);
-					recordsColl.add(uName);
-				}
-            }else
-            {
-            	foundOriginalMX = false;
-            	recordsColl = new Vector<URLName>();
-            }
-            
             /*
-             * If we found no MX record for the original hostname (the upper 
-             * level domains does not matter), then we add the original domain 
-             * name (identified with an A record) to the record collection, 
-             * because the mail exchange server could be the main server too.
-			 * 
-			 * We append the A record to the first place of the record 
-			 * collection, because the standard says if no MX record found then 
-			 * we should to try send email to the server identified by the A 
-			 * record.
+             * Sometimes we should send an email to a subdomain which does not
+             * have own MX record and MX server. At this point we should find an
+             * upper level domain and server where we can deliver our email.
+             *
+             * Example: subA.subB.domain.name has not own MX record and
+             * subB.domain.name is the mail exchange master of the subA domain
+             * too.
              */
-			if( !foundOriginalMX )
-			{
-				Record[] recordsTypeA = new Lookup(hostName, Type.A).run();
-				if (recordsTypeA != null && recordsTypeA.length > 0)
-				{
-					recordsColl.add(0, new URLName(SMTP_PROTOCOL_PREFIX + hostName));
-				}
-			}
+            if (records == null || records.length == 0) {
+                foundOriginalMX = false;
+                String upperLevelHostName = hostName;
+                while (records == null &&
+                        upperLevelHostName.indexOf('.') != upperLevelHostName.lastIndexOf('.') &&
+                        upperLevelHostName.lastIndexOf('.') != -1
+                ) {
+                    upperLevelHostName = upperLevelHostName.substring(upperLevelHostName.indexOf('.') + 1);
+                    records = new Lookup(upperLevelHostName, Type.MX).run();
+                }
+            }
 
-		} catch (TextParseException e) {
-			AspirinInternal.getConfiguration().getLogger().warn("DnsResolver.getMXRecordsForHost(): Failed get MX record for host '"+hostName+"'.",e);
-		}
+            if (records != null) {
+                // Sort in MX priority (higher number is lower priority)
+                Arrays.sort(records, Comparator.comparingInt(arg0 -> ((MXRecord) arg0).getPriority()));
+                // Create records collection
+                recordsColl = new Vector<>(records.length);
+                for (Record record : records) {
+                    MXRecord mx = (MXRecord) record;
+                    String targetString = mx.getTarget().toString();
+                    URLName uName = new URLName(
+                            SMTP_PROTOCOL_PREFIX +
+                                    targetString.substring(0, targetString.length() - 1)
+                    );
+                    recordsColl.add(uName);
+                }
+            } else foundOriginalMX = false;
 
-		return recordsColl;
-	}
+            /*
+             * If we found no MX record for the original hostname (the upper
+             * level domains does not matter), then we add the original domain
+             * name (identified with an A record) to the record collection,
+             * because the mail exchange server could be the main server too.
+             *
+             * We append the A record to the first place of the record
+             * collection, because the standard says if no MX record found then
+             * we should to try send email to the server identified by the A
+             * record.
+             */
+            if (!foundOriginalMX) {
+                Record[] recordsTypeA = new Lookup(hostName, Type.A).run();
+                if (recordsTypeA != null && recordsTypeA.length > 0) {
+                    recordsColl.add(0, new URLName(SMTP_PROTOCOL_PREFIX + hostName));
+                }
+            }
+
+        } catch (TextParseException e) {
+            AspirinInternal.getConfiguration().getLogger().warn("DnsResolver.getMXRecordsForHost(): Failed get MX record for host '" + hostName + "'.", e);
+        }
+
+        return recordsColl;
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/dns/ResolveHost.java
+++ b/src/main/java/org/masukomi/aspirin/core/dns/ResolveHost.java
@@ -1,54 +1,61 @@
 package org.masukomi.aspirin.core.dns;
 
-import java.util.Collection;
-
-import javax.mail.URLName;
-
+import org.jetbrains.annotations.NotNull;
 import org.masukomi.aspirin.core.AspirinInternal;
 import org.masukomi.aspirin.core.delivery.DeliveryContext;
 import org.masukomi.aspirin.core.delivery.DeliveryException;
 import org.masukomi.aspirin.core.delivery.DeliveryHandler;
 
+import javax.mail.URLName;
+import java.util.Collection;
+import java.util.Objects;
+
 /**
- * This delivery handler resolve recipient's MX records and append them to the 
- * delivery context. 
+ * This delivery handler resolve recipient's MX records and append them to the
+ * delivery context.
  * INPUT (REQUIRED) variables:
  * - none
  * OUTPUT (CREATED) variables:
  * - targetservers Collection&lt;URLName&gt;
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public class ResolveHost implements DeliveryHandler {
+    @Override
+    public void handle(@NotNull DeliveryContext dCtx) throws DeliveryException {
+        Objects.requireNonNull(dCtx, "dCtx");
+        String currentRecipient = dCtx.getQueueInfo().getRecipient();
+        // Get host MX records
+        String host = currentRecipient.substring(currentRecipient.lastIndexOf('@') + 1);
+        Collection<URLName> targetServers;
 
-	@Override
-	public void handle(DeliveryContext dCtx) throws DeliveryException {
-		String currentRecipient = dCtx.getQueueInfo().getRecipient();
-		// Get host MX records
-		String host = currentRecipient.substring(currentRecipient.lastIndexOf("@")+1);
-		Collection<URLName> targetServers = null;
-		try {
-			targetServers = DnsResolver.getMXRecordsForHost(host);
-			/*
+        try {
+            targetServers = DnsResolver.getMXRecordsForHost(host);
+            /*
              * If there was no target server, could be caused by a temporary
              * failure in domain name resolving. So we should to deliver this
              * email later.
              */
-			if( targetServers == null || targetServers.size() == 0 )
-            {
-                AspirinInternal.getLogger().warn("ResolveHost.handle(): No mail server found for: '{}'.",new Object[]{host});
+            if (targetServers == null || targetServers.isEmpty()) {
+                AspirinInternal.getLogger().warn(
+                        "ResolveHost.handle(): No mail server found for: '{}'.",
+                        host);
+
                 throw new DeliveryException("No MX record found. Temporary failure, trying again.", false);
             }
-           	AspirinInternal.getLogger().trace("ResolveHost.handle(): {} servers found for '{}'.",new Object[]{targetServers.size(),host});
-           	dCtx.addContextVariable("targetservers", targetServers);
-		} catch( DeliveryException de ) {
-			throw de;
-		} catch (Exception e) {
-			AspirinInternal.getLogger().error("ResolveHost.handle(): Could not get MX for host '"+host+"' defined by recipient '"+currentRecipient+"'.",e);
-			throw new DeliveryException("No MX record found. Temporary failure, trying again.", false);
-		}
 
-	}
+            AspirinInternal.getLogger().trace(
+                    "ResolveHost.handle(): {} servers found for '{}'.",
+                    targetServers.size(),
+                    host);
 
+            dCtx.addContextVariable("targetservers", targetServers);
+        } catch (RuntimeException e) {
+            AspirinInternal.getLogger().error(
+                    "ResolveHost.handle(): Could not get MX for host '" + host + "' defined by recipient '" + currentRecipient + "'.",
+                    e);
+
+            throw new DeliveryException("No MX record found. Temporary failure, trying again.", false, e);
+        }
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/listener/AspirinListener.java
+++ b/src/main/java/org/masukomi/aspirin/core/listener/AspirinListener.java
@@ -22,26 +22,30 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.masukomi.aspirin.core.listener;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
- * <p>This is a listener interface. This defines the mail delivery listeners, 
- * which could get messages if an email is delivered to a recipient (with the 
+ * <p>This is a listener interface. This defines the mail delivery listeners,
+ * which could get messages if an email is delivered to a recipient (with the
  * delivery result) and if an email is delivered to all recipients.</p>
- * 
+ *
  * @author kate rhodes,  masukomi at masukomi dot org
  * @author Laszlo Solova
- * 
  */
+@FunctionalInterface
 public interface AspirinListener {
-	/**
-	 * Called on delivery comes back with a persistent delivery result.
-	 * @param mailId Unique mail ID extracted from mail header.
-	 * @param recipient Recipient email address. It could be null - if state is 
-	 * finished and there were more recipients, then it is allowed to be null.
-	 * @param state Delivery result state: SENT, FAILED, FINISHED. FINISHED 
-	 * state is associated to a unique mail id - we get this state when all 
-	 * recipients has a persistent, final delivery state. 
-	 * @param resultContent Content of delivery result. On FINISHED state it 
-	 * could be null or empty.
-	 */
-	public void delivered(String mailId, String recipient, ResultState state, String resultContent);
+    /**
+     * Called on delivery comes back with a persistent delivery result.
+     *
+     * @param mailId        Unique mail ID extracted from mail header.
+     * @param recipient     Recipient email address. It could be null - if state is
+     *                      finished and there were more recipients, then it is allowed to be null.
+     * @param state         Delivery result state: SENT, FAILED, FINISHED. FINISHED
+     *                      state is associated to a unique mail id - we get this state when all
+     *                      recipients has a persistent, final delivery state.
+     * @param resultContent Content of delivery result. On FINISHED state it
+     *                      could be null or empty.
+     */
+    void delivered(@Nullable String mailId, @Nullable String recipient, @NotNull ResultState state, @Nullable String resultContent);
 }

--- a/src/main/java/org/masukomi/aspirin/core/listener/ListenerManager.java
+++ b/src/main/java/org/masukomi/aspirin/core/listener/ListenerManager.java
@@ -1,50 +1,53 @@
 package org.masukomi.aspirin.core.listener;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
+import org.jetbrains.annotations.NotNull;
 import org.masukomi.aspirin.core.AspirinInternal;
 import org.masukomi.aspirin.core.store.queue.DeliveryState;
 import org.masukomi.aspirin.core.store.queue.QueueInfo;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
 /**
- * 
  * @author Laszlo Solova
- *
  */
 public class ListenerManager {
-	private List<AspirinListener> listenerList = new ArrayList<AspirinListener>();
-	
-	public void add(AspirinListener listener) {
-		synchronized (listenerList) {
-			listenerList.add(listener);
-		}
-	}
-	public void remove(AspirinListener listener) {
-		synchronized (listenerList) {
-			listenerList.remove(listener);
-		}
-	}
-	
-	public void notifyListeners(QueueInfo qi) {
-		List<AspirinListener> listeners = null;
-		synchronized (listenerList) {
-			listeners = Collections.unmodifiableList(listenerList);
-		}
-		if( listeners != null && !listeners.isEmpty() )
-		{
-			for( AspirinListener listener : listeners )
-			{
-				if( qi.hasState(DeliveryState.FAILED) )
-					listener.delivered(qi.getMailid(), qi.getRecipient(), ResultState.FAILED, qi.getResultInfo());
-				else
-				if( qi.hasState(DeliveryState.SENT) )
-					listener.delivered(qi.getMailid(), qi.getRecipient(), ResultState.SENT, qi.getResultInfo());
-				if( AspirinInternal.getDeliveryManager().isCompleted(qi) )
-					listener.delivered(qi.getMailid(), qi.getRecipient(), ResultState.FINISHED, qi.getResultInfo());
-			}
-		}
-	}
+    @NotNull
+    private final List<AspirinListener> listenerList = new ArrayList<>();
 
+    public void add(@NotNull AspirinListener listener) {
+        Objects.requireNonNull(listener, "listener");
+
+        synchronized (listenerList) {
+            listenerList.add(listener);
+        }
+    }
+
+    public void remove(@NotNull AspirinListener listener) {
+        Objects.requireNonNull(listener, "listener");
+
+        synchronized (listenerList) {
+            listenerList.remove(listener);
+        }
+    }
+
+    public void notifyListeners(@NotNull QueueInfo qi) {
+        Objects.requireNonNull(qi, "qi");
+        List<AspirinListener> listeners;
+
+        synchronized (listenerList) {
+            listeners = Collections.unmodifiableList(listenerList);
+        }
+
+        if (!listeners.isEmpty()) listeners.forEach(listener -> {
+            if (qi.hasState(DeliveryState.FAILED))
+                listener.delivered(qi.getMailid(), qi.getRecipient(), ResultState.FAILED, qi.getResultInfo());
+            else if (qi.hasState(DeliveryState.SENT))
+                listener.delivered(qi.getMailid(), qi.getRecipient(), ResultState.SENT, qi.getResultInfo());
+            if (AspirinInternal.getDeliveryManager().isCompleted(qi))
+                listener.delivered(qi.getMailid(), qi.getRecipient(), ResultState.FINISHED, qi.getResultInfo());
+        });
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/listener/ResultState.java
+++ b/src/main/java/org/masukomi/aspirin/core/listener/ResultState.java
@@ -1,7 +1,7 @@
 package org.masukomi.aspirin.core.listener;
 
 public enum ResultState {
-	FAILED, // Delivery to a recipient failed
-	FINISHED, // Delivery to all recipient finished
-	SENT // Delivery to a recipient successed
+    FAILED, // Delivery to a recipient failed
+    FINISHED, // Delivery to all recipient finished
+    SENT // Delivery to a recipient succeeded
 }

--- a/src/main/java/org/masukomi/aspirin/core/store/mail/FileMailStore.java
+++ b/src/main/java/org/masukomi/aspirin/core/store/mail/FileMailStore.java
@@ -1,151 +1,164 @@
 package org.masukomi.aspirin.core.store.mail;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.masukomi.aspirin.core.AspirinInternal;
 
 import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
-
-import org.masukomi.aspirin.core.AspirinInternal;
+import java.io.*;
+import java.lang.ref.WeakReference;
+import java.util.*;
 
 /**
- * This store implementation is designed to reduce memory 
- * usage of MimeMessage instances. All MimeMessage instance 
- * are stored in files and in weak references too. So 
- * garbage collector can remove all large MimeMessage object 
+ * This store implementation is designed to reduce memory
+ * usage of MimeMessage instances. All MimeMessage instance
+ * are stored in files and in weak references too. So
+ * garbage collector can remove all large MimeMessage object
  * from memory if necessary.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public class FileMailStore implements MailStore {
-	
-	private File rootDir;
-	private int subDirCount = 3;
-	private Random rand = new Random();
-	private Map<String, WeakReference<MimeMessage>> messageMap = new HashMap<String, WeakReference<MimeMessage>>();
-	private Map<String, String> messagePathMap = new HashMap<String, String>();
-	
-	@Override
-	public MimeMessage get(String mailid) {
-		WeakReference<MimeMessage> msgRef = messageMap.get(mailid);
-		MimeMessage msg = null;
-		if( msgRef != null )
-		{
-			msg = msgRef.get();
-			if( msg == null )
-			{
-				try {
-					msg = new MimeMessage(Session.getDefaultInstance(System.getProperties()),new FileInputStream(new File(messagePathMap.get(mailid))));
-					msgRef = new WeakReference<MimeMessage>(msg);
-				} catch (FileNotFoundException e) {
-					AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName()+" No file representation found for name "+mailid,e);
-				} catch (MessagingException e) {
-					AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName()+" There is a messaging exception with name "+mailid,e);
-				}
-			}
-		}
-		return msg;
-	}
-	
-	@Override
-	public List<String> getMailIds() {
-		return new ArrayList<String>(messageMap.keySet());
-	}
-	
-	@Override
-	public void init() {
-		if( !rootDir.exists() ) { return; }
-		File[] subdirs = rootDir.listFiles();
-		if( subdirs == null ) { return; }
-		for( File subDir : subdirs )
-		{
-			if( subDir.isDirectory() )
-			{
-				File[] subdirFiles = subDir.listFiles();
-				if( subdirFiles == null ) { continue; }
-				for( File msgFile : subdirFiles )
-				{
-					try {
-						MimeMessage msg = new MimeMessage(Session.getDefaultInstance(System.getProperties()),new FileInputStream(msgFile));
-						String mailid = AspirinInternal.getMailID(msg);
-						synchronized (messageMap) {
-							messageMap.put(mailid, new WeakReference<MimeMessage>(msg));
-							messagePathMap.put(mailid, msgFile.getAbsolutePath());
-						}
-					} catch (FileNotFoundException e) {
-						AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName()+" No file representation found with name "+msgFile.getAbsolutePath(),e);
-					} catch (MessagingException e) {
-						AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName()+" There is a messaging exception in file "+msgFile.getAbsolutePath(),e);
-					}
-				}
-			}
-		}
-	}
+    @NotNull
+    private final Random rand = new Random();
+    @NotNull
+    private final Map<String, WeakReference<MimeMessage>> messageMap = new HashMap<>();
+    @NotNull
+    private final Map<String, String> messagePathMap = new HashMap<>();
+    @Nullable
+    private File rootDir;
+    private int subDirCount = 3;
 
-	@Override
-	public void remove(String mailid) {
-		synchronized (messageMap) {
-			messageMap.remove(mailid);
-			synchronized (messagePathMap) {
-				File f = new File(messagePathMap.get(mailid));
-				f.delete();
-				messagePathMap.remove(mailid);
-			}
-		}
-	}
-	
-	@Override
-	public void set(String mailid, MimeMessage msg) {
-		String filepath;
-		// Create file path
-		if( rootDir == null )
-			throw new RuntimeException(getClass().getSimpleName()+" Please set up root directory.");
-		String subDirName = String.valueOf(rand.nextInt(subDirCount));
-		File dir = new File(rootDir, subDirName);
-		if( !dir.exists() )
-			dir.mkdirs();
-		filepath = new File(dir, mailid+".msg").getAbsolutePath();
-		// Save informations
-		try {
-			File msgFile = new File(filepath);
-			if( msgFile.exists() ) { msgFile.delete(); }
-			if( !msgFile.exists() ) { msgFile.createNewFile(); }
-			msg.writeTo(new FileOutputStream(msgFile));
-			synchronized (messageMap) {
-				messageMap.put(mailid, new WeakReference<MimeMessage>(msg));
-				messagePathMap.put(mailid, filepath);
-			}
-		} catch (FileNotFoundException e) {
-			AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName()+" No file representation found for name "+mailid,e);
-		} catch (IOException e) {
-			AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName()+" Could not write file for name "+mailid,e);
-		} catch (MessagingException e) {
-			AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName()+" There is a messaging exception with name "+mailid,e);
-		}
-	}
-	
-	public void setRootDir(File rootDir) {
-		this.rootDir = rootDir;
-	}
-	public File getRootDir() {
-		return rootDir;
-	}
-	public void setSubDirCount(int subDirCount) {
-		this.subDirCount = subDirCount;
-	}
-	public int getSubDirCount() {
-		return subDirCount;
-	}
+    @Override
+    @Nullable
+    public MimeMessage get(@NotNull String mailid) {
+        Objects.requireNonNull(mailid, "mailid");
+        WeakReference<MimeMessage> msgRef = messageMap.get(mailid);
+        MimeMessage msg = null;
 
+        if (msgRef != null) {
+            msg = msgRef.get();
+            if (msg == null) {
+                try {
+                    msg = new MimeMessage(Session.getDefaultInstance(System.getProperties()), new FileInputStream(new File(messagePathMap.get(mailid))));
+                } catch (FileNotFoundException e) {
+                    AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName() + " No file representation found for name " + mailid, e);
+                } catch (MessagingException e) {
+                    AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName() + " There is a messaging exception with name " + mailid, e);
+                }
+            }
+        }
+
+        return msg;
+    }
+
+    @Override
+    @NotNull
+    public List<String> getMailIds() {
+        return new ArrayList<>(messageMap.keySet());
+    }
+
+    @Override
+    public void init() {
+        if (!rootDir.exists()) return;
+        File[] subdirs = rootDir.listFiles();
+        if (subdirs == null) return;
+
+        Arrays.stream(subdirs)
+                .filter(File::isDirectory)
+                .map(File::listFiles)
+                .filter(Objects::nonNull)
+                .flatMap(Arrays::stream)
+                .forEachOrdered(msgFile -> {
+                    try {
+                        MimeMessage msg = new MimeMessage(Session.getDefaultInstance(System.getProperties()), new FileInputStream(msgFile));
+                        String mailid = AspirinInternal.getMailID(msg);
+
+                        synchronized (messageMap) {
+                            messageMap.put(mailid, new WeakReference<>(msg));
+                            messagePathMap.put(mailid, msgFile.getAbsolutePath());
+                        }
+                    } catch (FileNotFoundException e) {
+                        AspirinInternal.getConfiguration().getLogger().error(
+                                getClass().getSimpleName() + " No file representation found with name " + msgFile.getAbsolutePath(),
+                                e);
+                    } catch (MessagingException e) {
+                        AspirinInternal.getConfiguration().getLogger().error(
+                                getClass().getSimpleName() + " There is a messaging exception in file " + msgFile.getAbsolutePath(),
+                                e);
+                    }
+                });
+    }
+
+    @Override
+    public void remove(@Nullable String mailid) {
+        synchronized (messageMap) {
+            messageMap.remove(mailid);
+
+            synchronized (messagePathMap) {
+                File file = new File(messagePathMap.get(mailid));
+                file.delete();
+                messagePathMap.remove(mailid);
+            }
+        }
+    }
+
+    @Override
+    public void set(@NotNull String mailid, @NotNull MimeMessage msg) {
+        Objects.requireNonNull(mailid, "mailid");
+        Objects.requireNonNull(msg, "msg");
+        String filepath;
+
+        // Create file path
+        if (rootDir == null)
+            throw new IllegalStateException(getClass().getSimpleName() + " Please set up root directory.");
+
+        String subDirName = String.valueOf(rand.nextInt(subDirCount));
+        File dir = new File(rootDir, subDirName);
+
+        if (!dir.exists())
+            dir.mkdirs();
+
+        filepath = new File(dir, mailid + ".msg").getAbsolutePath();
+
+        // Save information
+        try {
+            File msgFile = new File(filepath);
+            if (msgFile.exists()) {
+                msgFile.delete();
+            }
+            if (!msgFile.exists()) {
+                msgFile.createNewFile();
+            }
+            msg.writeTo(new FileOutputStream(msgFile));
+            synchronized (messageMap) {
+                messageMap.put(mailid, new WeakReference<>(msg));
+                messagePathMap.put(mailid, filepath);
+            }
+        } catch (FileNotFoundException e) {
+            AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName() + " No file representation found for name " + mailid, e);
+        } catch (IOException e) {
+            AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName() + " Could not write file for name " + mailid, e);
+        } catch (MessagingException e) {
+            AspirinInternal.getConfiguration().getLogger().error(getClass().getSimpleName() + " There is a messaging exception with name " + mailid, e);
+        }
+    }
+
+    public @Nullable File getRootDir() {
+        return rootDir;
+    }
+
+    public void setRootDir(@Nullable File rootDir) {
+        this.rootDir = rootDir;
+    }
+
+    public int getSubDirCount() {
+        return subDirCount;
+    }
+
+    public void setSubDirCount(int subDirCount) {
+        this.subDirCount = subDirCount;
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/store/mail/MailStore.java
+++ b/src/main/java/org/masukomi/aspirin/core/store/mail/MailStore.java
@@ -1,22 +1,29 @@
 package org.masukomi.aspirin.core.store.mail;
 
-import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.mail.internet.MimeMessage;
+import java.util.List;
 
 /**
- * This store contain all MimeMessage instances. This is useful, 
- * when we try to reduce memory usage, because we can store all 
- * MimeMessage objects in files or in RDBMS or in other places, 
+ * This store contain all MimeMessage instances. This is useful,
+ * when we try to reduce memory usage, because we can store all
+ * MimeMessage objects in files or in RDBMS or in other places,
  * instead of memory.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public interface MailStore {
-	public MimeMessage get(String mailid);
-	public List<String> getMailIds();
-	public void init();
-	public void remove(String mailid);
-	public void set(String mailid, MimeMessage msg);
+    @Nullable
+    MimeMessage get(@NotNull String mailid);
+
+    @NotNull
+    List<String> getMailIds();
+
+    void init();
+
+    void remove(@Nullable String mailid);
+
+    void set(@NotNull String mailid, @NotNull MimeMessage msg);
 }

--- a/src/main/java/org/masukomi/aspirin/core/store/mail/SimpleMailStore.java
+++ b/src/main/java/org/masukomi/aspirin/core/store/mail/SimpleMailStore.java
@@ -1,50 +1,47 @@
 package org.masukomi.aspirin.core.store.mail;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.mail.internet.MimeMessage;
-
-
+import java.util.*;
 
 /**
- * This store implementation has a simple hashmap to 
- * store all MimeMessage objects. Please, be careful: 
- * if you has a lot of objects in memory it could cause 
+ * This store implementation has a simple hashmap to
+ * store all MimeMessage objects. Please, be careful:
+ * if you has a lot of objects in memory it could cause
  * OutOfMemoryError.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public class SimpleMailStore implements MailStore {
-	
-	private HashMap<String, MimeMessage> messageMap = new HashMap<String, MimeMessage>();
-	
+    @NotNull
+    private final Map<String, MimeMessage> messageMap = new HashMap<>();
 
-	@Override
-	public MimeMessage get(String mailid) {
-		return messageMap.get(mailid);
-	}
-	
-	@Override
-	public List<String> getMailIds() {
-		return new ArrayList<String>(messageMap.keySet());
-	}
-	
-	@Override
-	public void init() {
-		// Do nothing	
-	}
+    @Override
+    @Nullable
+    public MimeMessage get(@NotNull String mailid) {
+        return messageMap.get(Objects.requireNonNull(mailid, "mailid"));
+    }
 
-	@Override
-	public void remove(String mailid) {
-		messageMap.remove(mailid);
-	}
+    @Override
+    @NotNull
+    public List<String> getMailIds() {
+        return new ArrayList<>(messageMap.keySet());
+    }
 
-	@Override
-	public void set(String mailid, MimeMessage msg) {
-		messageMap.put(mailid, msg);
-	}
+    @Override
+    public void init() {
+        // Do nothing
+    }
 
+    @Override
+    public void remove(@Nullable String mailid) {
+        messageMap.remove(mailid);
+    }
+
+    @Override
+    public void set(@NotNull String mailid, @Nullable MimeMessage msg) {
+        messageMap.put(Objects.requireNonNull(mailid, "mailid"), msg);
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/store/queue/DeliveryState.java
+++ b/src/main/java/org/masukomi/aspirin/core/store/queue/DeliveryState.java
@@ -2,22 +2,22 @@ package org.masukomi.aspirin.core.store.queue;
 
 /**
  * Sending states.
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public enum DeliveryState {
-	SENT(0), // Email sent
-	FAILED(1), // Email sending failed
-	QUEUED(2), // Email is queued
-	IN_PROGRESS(3) // Email is currently in processing
-	;
-	private int stateId = 0;
-	private DeliveryState(int stateId) {
-		this.stateId = stateId;
-	}
-	public int getStateId() {
-		return stateId;
-	}
+    SENT(0), // Email sent
+    FAILED(1), // Email sending failed
+    QUEUED(2), // Email is queued
+    IN_PROGRESS(3) // Email is currently in processing
+    ;
+    private final int stateId;
 
+    DeliveryState(int stateId) {
+        this.stateId = stateId;
+    }
+
+    public int getStateId() {
+        return stateId;
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/store/queue/QueueInfo.java
+++ b/src/main/java/org/masukomi/aspirin/core/store/queue/QueueInfo.java
@@ -1,129 +1,138 @@
 package org.masukomi.aspirin.core.store.queue;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.masukomi.aspirin.core.AspirinInternal;
 
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
- * 
  * @author Laszlo Solova
- *
  */
 public class QueueInfo {
-	private String mailid;
-	private String recipient;
-	private String resultInfo;
-	private long attempt = 0;
-	private int attemptCount = 0;
-	private long expiry = -1L;
-	private DeliveryState state = DeliveryState.QUEUED;
-	
-	private transient boolean notifiedAlready = false;
-	private transient String complexId = null;
-	
-	public String getComplexId() {
-		if( complexId == null )
-			complexId = mailid+"-"+recipient;
-		return complexId;
-	}
-	
-	public String getMailid() {
-		return mailid;
-	}
-	public void setMailid(String mailid) {
-		this.mailid = mailid;
-	}
-	public String getRecipient() {
-		return recipient;
-	}
-	public void setRecipient(String recipient) {
-		this.recipient = recipient;
-	}
-	public String getResultInfo() {
-		return resultInfo;
-	}
-	public void setResultInfo(String resultInfo) {
-		this.resultInfo = resultInfo;
-	}
-	public long getAttempt() {
-		return attempt;
-	}
-	public void setAttempt(long attempt) {
-		this.attempt = attempt;
-	}
-	public int getAttemptCount() {
-		return attemptCount;
-	}
-	public void incAttemptCount() {
-		this.attemptCount++;
-	}
-	public void setAttemptCount(int attemptCount) {
-		this.attemptCount = attemptCount;
-	}
-	public long getExpiry() {
-		return expiry;
-	}
-	public void setExpiry(long expiry) {
-		this.expiry = expiry;
-	}
-	public DeliveryState getState() {
-		return state;
-	}
-	/**
-	 * This method set original state, and notify all AspirinListener about the 
-	 * state change, if the new change is not QUEUED. Please call only once, on 
-	 * persisting - if persisted - this item.
-	 * 
-	 * For example in {@link SimpleQueueStore} we use only once: in the 
-	 * setSendingResult() method. 
-	 * 
-	 * @param state The new state.
-	 */
-	public void setState(DeliveryState state) {
-		this.state = state;
-		if( AspirinInternal.getListenerManager() != null && !notifiedAlready && !hasState(DeliveryState.QUEUED, DeliveryState.IN_PROGRESS) )
-		{
-			AspirinInternal.getListenerManager().notifyListeners(this);
-			notifiedAlready = true;
-		}
-	}
-	
-	public boolean hasState(DeliveryState... states) {
-		for( DeliveryState st : states )
-		{
-			if( st.equals(this.state) )
-				return true;
-			
-		}
-		return false;
-	}
-	
-	public boolean isSendable() {
-		return (
-				hasState(DeliveryState.QUEUED) &&
-				getAttempt() < System.currentTimeMillis()
-		);
-	}
-	
-	public boolean isInTimeBounds() {
-		return (
-				(getExpiry() == -1 || System.currentTimeMillis() < getExpiry()) &&
-				getAttemptCount() < AspirinInternal.getConfiguration().getDeliveryAttemptCount()
-		);
-	}
-	
+    @Nullable
+    private String mailid;
+    @Nullable
+    private String recipient;
+    @Nullable
+    private String resultInfo;
+    private long attempt;
+    private int attemptCount;
+    private long expiry = -1L;
+    @NotNull
+    private DeliveryState state = DeliveryState.QUEUED;
+
+    private boolean notifiedAlready;
+    @Nullable
+    private String complexId;
+    @Nullable
+    private String qiToString;
+
+    public String getComplexId() {
+        if (complexId == null)
+            complexId = mailid + "-" + recipient;
+        return complexId;
+    }
+
+    public @Nullable String getMailid() {
+        return mailid;
+    }
+
+    public void setMailid(@Nullable String mailid) {
+        this.mailid = mailid;
+    }
+
+    public @Nullable String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(@Nullable String recipient) {
+        this.recipient = recipient;
+    }
+
+    public @Nullable String getResultInfo() {
+        return resultInfo;
+    }
+
+    public void setResultInfo(@Nullable String resultInfo) {
+        this.resultInfo = resultInfo;
+    }
+
+    public long getAttempt() {
+        return attempt;
+    }
+
+    public void setAttempt(long attempt) {
+        this.attempt = attempt;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    public void setAttemptCount(int attemptCount) {
+        this.attemptCount = attemptCount;
+    }
+
+    public void incAttemptCount() {
+        attemptCount++;
+    }
+
+    public long getExpiry() {
+        return expiry;
+    }
+
+    public void setExpiry(long expiry) {
+        this.expiry = expiry;
+    }
+
+    public @NotNull DeliveryState getState() {
+        return state;
+    }
+
+    /**
+     * This method set original state, and notify all AspirinListener about the
+     * state change, if the new change is not QUEUED. Please call only once, on
+     * persisting - if persisted - this item.
+     * <p>
+     * For example in {@link SimpleQueueStore} we use only once: in the
+     * setSendingResult() method.
+     *
+     * @param state The new state.
+     */
+    public void setState(@NotNull DeliveryState state) {
+        this.state = Objects.requireNonNull(state, "state");
+        if (AspirinInternal.getListenerManager() != null && !notifiedAlready && !hasState(DeliveryState.QUEUED, DeliveryState.IN_PROGRESS)) {
+            AspirinInternal.getListenerManager().notifyListeners(this);
+            notifiedAlready = true;
+        }
+    }
+
+    public boolean hasState(@NotNull DeliveryState... states) {
+        Objects.requireNonNull(states, "states");
+        return Arrays.stream(states).anyMatch(st -> st == state);
+    }
+
+    public boolean isSendable() {
+        return hasState(DeliveryState.QUEUED) &&
+                attempt < System.currentTimeMillis();
+    }
+
 //	public abstract void save();
 //	public abstract void load();
-	
-	private transient String qiToString = null;
-	@Override
-	public String toString() {
-		if( qiToString == null )
-		{
-			StringBuilder sb = new StringBuilder();
-			sb.append("Mail: [id=").append(mailid).append("; recipient=").append(recipient).append("];");
-			qiToString = sb.toString();
-		}
-		return qiToString;
-	}
 
+    public boolean isInTimeBounds() {
+        return (expiry == -1L || System.currentTimeMillis() < expiry) &&
+                attemptCount < AspirinInternal.getConfiguration().getDeliveryAttemptCount();
+    }
+
+    @Override
+    @NotNull
+    public String toString() {
+        if (qiToString == null)
+            qiToString = "Mail: [id=" + mailid + "; recipient=" + recipient + "];";
+
+        return qiToString;
+    }
 }

--- a/src/main/java/org/masukomi/aspirin/core/store/queue/QueueInfo.java
+++ b/src/main/java/org/masukomi/aspirin/core/store/queue/QueueInfo.java
@@ -30,8 +30,7 @@ public class QueueInfo {
     private String qiToString;
 
     public String getComplexId() {
-        if (complexId == null)
-            complexId = mailid + "-" + recipient;
+        if (complexId == null) complexId = mailid + "-" + recipient;
         return complexId;
     }
 

--- a/src/main/java/org/masukomi/aspirin/core/store/queue/QueueStore.java
+++ b/src/main/java/org/masukomi/aspirin/core/store/queue/QueueStore.java
@@ -1,45 +1,60 @@
 package org.masukomi.aspirin.core.store.queue;
 
-import java.util.Collection;
-import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
+import java.util.List;
 
 
 /**
- * <p>Experimental interface to set up Quality of Service features. It could be 
+ * <p>Experimental interface to set up Quality of Service features. It could be
  * changed in the next versions.</p>
- * 
- * @author Laszlo Solova
  *
+ * @author Laszlo Solova
  */
 public interface QueueStore {
-	public void add(String mailid, long expire, Collection<InternetAddress> recipients) throws MessagingException;
-	/**
-	 * This method is called to clean QueueStore. In cleaning process the 
-	 * QueueStore have to remove all completed mailid, and after finishing it 
-	 * gives back list of unfinished mailids.
-	 * @return List of used mailids.
-	 */
-	public List<String> clean();
-	public QueueInfo createQueueInfo();
-	public long getNextAttempt(String mailid, String recipient);
-	public boolean hasBeenRecipientHandled(String mailid, String recipient);
-	public void init();
-	public boolean isCompleted(String mailid);
-	/**
-	 * It gives back the next sendable QueueInfo object.
-	 * QueueInfo has
-	 * - the next valid attempt time (attempt before current time and attemptcount is under limit)
-	 * - valid expiry (expiry is unset or is after current time)
-	 * - QUEUED status
-	 * 
-	 * @return next sendable QueueInfo or null
-	 */
-	public QueueInfo next();
-	public void remove(String mailid);
-	public void removeRecipient(String recipient);
-	public void setSendingResult(QueueInfo qi);
-	public int size();
+    void add(@Nullable String mailid, long expiry, @NotNull Iterable<? extends InternetAddress> recipients) throws MessagingException;
+
+    /**
+     * This method is called to clean QueueStore. In cleaning process the
+     * QueueStore have to remove all completed mailid, and after finishing it
+     * gives back list of unfinished mailids.
+     *
+     * @return List of used mailids.
+     */
+    @NotNull
+    List<String> clean();
+
+    @NotNull
+    QueueInfo createQueueInfo();
+
+    long getNextAttempt(@Nullable String mailid, @Nullable String recipient);
+
+    boolean hasBeenRecipientHandled(@Nullable String mailid, @Nullable String recipient);
+
+    void init();
+
+    boolean isCompleted(@Nullable String mailid);
+
+    /**
+     * It gives back the next sendable QueueInfo object.
+     * QueueInfo has
+     * - the next valid attempt time (attempt before current time and attemptcount is under limit)
+     * - valid expiry (expiry is unset or is after current time)
+     * - QUEUED status
+     *
+     * @return next sendable QueueInfo or null
+     */
+    @Nullable
+    QueueInfo next();
+
+    void remove(@Nullable String mailid);
+
+    void removeRecipient(@Nullable String recipient);
+
+    void setSendingResult(QueueInfo qi);
+
+    int size();
 }

--- a/src/main/java/org/masukomi/aspirin/core/store/queue/SimpleQueueStore.java
+++ b/src/main/java/org/masukomi/aspirin/core/store/queue/SimpleQueueStore.java
@@ -1,208 +1,184 @@
 package org.masukomi.aspirin.core.store.queue;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.masukomi.aspirin.core.AspirinInternal;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
-
-import org.masukomi.aspirin.core.AspirinInternal;
-
+import java.util.*;
 
 /**
- * 
  * @author Laszlo Solova
- *
  */
 public class SimpleQueueStore implements QueueStore {
-	
-	private List<QueueInfo> queueInfoList = new LinkedList<QueueInfo>();
-	private Map<String, QueueInfo> queueInfoByMailidAndRecipient = new HashMap<String, QueueInfo>();
-	private Map<String, List<QueueInfo>> queueInfoByMailid = new HashMap<String, List<QueueInfo>>();
-	private Map<String, List<QueueInfo>> queueInfoByRecipient = new HashMap<String, List<QueueInfo>>();
-	private Object lock = new Object();
-	private Comparator<QueueInfo> queueInfoComparator = new Comparator<QueueInfo>() {
-		@Override
-		public int compare(QueueInfo o1, QueueInfo o2) {
-			return (int)(o2.getAttempt()-o1.getAttempt());
-		}
-	};
-	
-	@Override
-	public void add(String mailid, long expiry, Collection<InternetAddress> recipients) throws MessagingException {
-		try {
-			for( InternetAddress recipient : recipients )
-			{
-				QueueInfo queueInfo = new QueueInfo();
-				queueInfo.setExpiry(expiry);
-				queueInfo.setMailid(mailid);
-				queueInfo.setRecipient(recipient.getAddress());
-				synchronized (lock) {
-					
-					queueInfoList.add(queueInfo);
-					
-					queueInfoByMailidAndRecipient.put(createSearchKey(queueInfo.getMailid(),queueInfo.getRecipient()), queueInfo);
-					
-					if( !queueInfoByMailid.containsKey(queueInfo.getMailid()) )
-						queueInfoByMailid.put(queueInfo.getMailid(), new ArrayList<QueueInfo>());
-					queueInfoByMailid.get(queueInfo.getMailid()).add(queueInfo);
-					
-					if( !queueInfoByRecipient.containsKey(queueInfo.getRecipient()) )
-						queueInfoByRecipient.put(queueInfo.getRecipient(), new ArrayList<QueueInfo>());
-					queueInfoByRecipient.get(queueInfo.getRecipient()).add(queueInfo);
-					
-				}
-			}
-		} catch (Exception e) {
-			throw new MessagingException("Message queueing failed: "+mailid, e);
-		}
-	}
-	
-	@Override
-	public List<String> clean() {
-		List<String> mailidList = null;
-		synchronized (lock) {
-			mailidList = new ArrayList<String>(queueInfoByMailid.keySet());
-		}
-		Iterator<String> mailidIt = mailidList.iterator();
-		while( mailidIt.hasNext() )
-		{
-			String mailid = mailidIt.next();
-			if( isCompleted(mailid) )
-			{
-				remove(mailid);
-				mailidIt.remove();
-			}
-		}
-		return mailidList;
-	}
-	
-	@Override
-	public QueueInfo createQueueInfo() {
-		return new QueueInfo();
-	}
-	
-	@Override
-	public long getNextAttempt(String mailid, String recipient) {
-		QueueInfo qInfo = queueInfoByMailidAndRecipient.get(createSearchKey(mailid, recipient));
-		if( qInfo != null && qInfo.hasState(DeliveryState.QUEUED) )
-			return qInfo.getAttempt();
-		return -1;
-	}
+    @NotNull
+    private final List<QueueInfo> queueInfoList = new LinkedList<>();
+    @NotNull
+    private final Map<String, QueueInfo> queueInfoByMailidAndRecipient = new HashMap<>();
+    @NotNull
+    private final Map<String, List<QueueInfo>> queueInfoByMailid = new HashMap<>();
+    @NotNull
+    private final Map<String, List<QueueInfo>> queueInfoByRecipient = new HashMap<>();
+    @NotNull
+    private final Object lock = new Object();
+    @NotNull
+    private final Comparator<QueueInfo> queueInfoComparator = (o1, o2) -> (int) (o2.getAttempt() - o1.getAttempt());
 
-	@Override
-	public boolean hasBeenRecipientHandled(String mailid, String recipient) {
-		QueueInfo qInfo = queueInfoByMailidAndRecipient.get(createSearchKey(mailid, recipient));
-		return ( qInfo != null && qInfo.hasState(DeliveryState.FAILED, DeliveryState.SENT) );
-	}
-	
-	@Override
-	public void init() {
-		// Do nothing	
-	}
-	
-	@Override
-	public boolean isCompleted(String mailid) {
-		List<QueueInfo> qibmList = queueInfoByMailid.get(mailid);
-		if( qibmList != null )
-		{
-			for( QueueInfo sqi : qibmList )
-			{
-				if( sqi.hasState(DeliveryState.IN_PROGRESS, DeliveryState.QUEUED) )
-					return false;
-			}
-		}
-		return true;
-	}
-	
-	@Override
-	public QueueInfo next() {
-		Collections.sort(queueInfoList, queueInfoComparator);
-		if( !queueInfoList.isEmpty() )
-		{
-			synchronized (lock) {
-				ListIterator<QueueInfo> queueInfoIt = queueInfoList.listIterator();
-				while( queueInfoIt.hasNext() )
-				{
-					QueueInfo qi = queueInfoIt.next();
-					if( qi.isSendable() ) {
-						if( !qi.isInTimeBounds() )
-						{
-							if( qi.getResultInfo() == null || qi.getResultInfo().isEmpty() )
-								qi.setResultInfo("Delivery is out of time or attempt.");
-							qi.setState(DeliveryState.FAILED);
-							setSendingResult(qi);
-						}
-						else
-						{	
-							qi.setState(DeliveryState.IN_PROGRESS);
-							return qi;
-						}
-					}
-				}
-			}
-		}
-		return null;
-	}
-	
-	@Override
-	public void remove(String mailid) {
-		synchronized (lock) {
-			List<QueueInfo> removeableQueueInfos = queueInfoByMailid.remove(mailid);
-			if( removeableQueueInfos != null )
-			{
-				for( QueueInfo sqi : removeableQueueInfos )
-				{
-					queueInfoByMailidAndRecipient.remove(createSearchKey(sqi.getMailid(), sqi.getRecipient()));
-					queueInfoByRecipient.get(sqi.getRecipient()).remove(sqi);
-				}
-			}
-		}
-	}
+    @NotNull
+    private static String createSearchKey(@Nullable String mailid, @Nullable String recipient) {
+        return mailid + "-" + recipient;
+    }
 
-	@Override
-	public void removeRecipient(String recipient) {
-		synchronized (lock) {
-			List<QueueInfo> removeableQueueInfos = queueInfoByRecipient.remove(recipient);
-			if( removeableQueueInfos != null )
-			{
-				for( QueueInfo sqi : removeableQueueInfos )
-				{
-					queueInfoByMailidAndRecipient.remove(createSearchKey(sqi.getMailid(), sqi.getRecipient()));
-					queueInfoByMailid.get(sqi.getMailid()).remove(sqi);
-				}
-			}
-		}
-	}
+    @Override
+    public void add(@Nullable String mailid, long expiry, @NotNull Iterable<? extends InternetAddress> recipients) throws MessagingException {
+        Objects.requireNonNull(recipients, "recipients");
 
-	@Override
-	public void setSendingResult(QueueInfo qi) {
-		synchronized (lock) {
-			QueueInfo uniqueQueueInfo = queueInfoByMailidAndRecipient.get(createSearchKey(qi.getMailid(), qi.getRecipient()));
-			if( uniqueQueueInfo != null )
-			{
-				uniqueQueueInfo.setAttempt(System.currentTimeMillis()+AspirinInternal.getConfiguration().getDeliveryAttemptDelay());
-				uniqueQueueInfo.incAttemptCount();
-				uniqueQueueInfo.setState(qi.getState());
-			}
-		}
-	}
-	
-	@Override
-	public int size() {
-		return queueInfoByMailid.size();
-	}
-	
-	private String createSearchKey(String mailid, String recipient) {
-		return mailid+"-"+recipient;
-	}
+        try {
+            for (InternetAddress recipient : recipients) {
+                QueueInfo queueInfo = new QueueInfo();
+                queueInfo.setExpiry(expiry);
+                queueInfo.setMailid(mailid);
+                queueInfo.setRecipient(recipient.getAddress());
+                synchronized (lock) {
 
+                    queueInfoList.add(queueInfo);
+
+                    queueInfoByMailidAndRecipient.put(createSearchKey(queueInfo.getMailid(), queueInfo.getRecipient()), queueInfo);
+
+                    if (!queueInfoByMailid.containsKey(queueInfo.getMailid()))
+                        queueInfoByMailid.put(queueInfo.getMailid(), new ArrayList<>());
+                    queueInfoByMailid.get(queueInfo.getMailid()).add(queueInfo);
+
+                    if (!queueInfoByRecipient.containsKey(queueInfo.getRecipient()))
+                        queueInfoByRecipient.put(queueInfo.getRecipient(), new ArrayList<>());
+                    queueInfoByRecipient.get(queueInfo.getRecipient()).add(queueInfo);
+
+                }
+            }
+        } catch (RuntimeException e) {
+            throw new MessagingException("Message queueing failed: " + mailid, e);
+        }
+    }
+
+    @NotNull
+    @Override
+    public List<String> clean() {
+        List<String> mailidList;
+        synchronized (lock) {
+            mailidList = new ArrayList<>(queueInfoByMailid.keySet());
+        }
+        Iterator<String> mailidIt = mailidList.iterator();
+        while (mailidIt.hasNext()) {
+            String mailid = mailidIt.next();
+            if (isCompleted(mailid)) {
+                remove(mailid);
+                mailidIt.remove();
+            }
+        }
+        return mailidList;
+    }
+
+    @NotNull
+    @Override
+    public QueueInfo createQueueInfo() {
+        return new QueueInfo();
+    }
+
+    @Override
+    public long getNextAttempt(@Nullable String mailid, @Nullable String recipient) {
+        QueueInfo qInfo = queueInfoByMailidAndRecipient.get(createSearchKey(mailid, recipient));
+        if (qInfo != null && qInfo.hasState(DeliveryState.QUEUED))
+            return qInfo.getAttempt();
+        return -1L;
+    }
+
+    @Override
+    public boolean hasBeenRecipientHandled(@Nullable String mailid, @Nullable String recipient) {
+        QueueInfo qInfo = queueInfoByMailidAndRecipient.get(createSearchKey(mailid, recipient));
+        return (qInfo != null && qInfo.hasState(DeliveryState.FAILED, DeliveryState.SENT));
+    }
+
+    @Override
+    public void init() {
+        // Do nothing
+    }
+
+    @Override
+    public boolean isCompleted(@Nullable String mailid) {
+        List<QueueInfo> qibmList = queueInfoByMailid.get(mailid);
+
+        if (qibmList != null)
+            return qibmList.stream().noneMatch(sqi -> sqi.hasState(DeliveryState.IN_PROGRESS, DeliveryState.QUEUED));
+
+        return true;
+    }
+
+    @Override
+    @Nullable
+    public QueueInfo next() {
+        Collections.sort(queueInfoList, queueInfoComparator);
+
+        if (!queueInfoList.isEmpty())
+            synchronized (lock) {
+                for (QueueInfo qi : queueInfoList)
+                    if (qi.isSendable()) {
+                        if (!qi.isInTimeBounds()) {
+                            if (qi.getResultInfo() == null || qi.getResultInfo().isEmpty())
+                                qi.setResultInfo("Delivery is out of time or attempt.");
+                            qi.setState(DeliveryState.FAILED);
+                            setSendingResult(qi);
+                        } else {
+                            qi.setState(DeliveryState.IN_PROGRESS);
+                            return qi;
+                        }
+                    }
+            }
+
+        return null;
+    }
+
+    @Override
+    public void remove(@Nullable String mailid) {
+        synchronized (lock) {
+            Iterable<QueueInfo> removeableQueueInfos = queueInfoByMailid.remove(mailid);
+
+            if (removeableQueueInfos != null) for (QueueInfo sqi : removeableQueueInfos) {
+                queueInfoByMailidAndRecipient.remove(createSearchKey(sqi.getMailid(), sqi.getRecipient()));
+                queueInfoByRecipient.get(sqi.getRecipient()).remove(sqi);
+            }
+        }
+    }
+
+    @Override
+    public void removeRecipient(@Nullable String recipient) {
+        synchronized (lock) {
+            Iterable<QueueInfo> removeableQueueInfos = queueInfoByRecipient.remove(recipient);
+
+            if (removeableQueueInfos != null) for (QueueInfo sqi : removeableQueueInfos) {
+                queueInfoByMailidAndRecipient.remove(createSearchKey(sqi.getMailid(), sqi.getRecipient()));
+                queueInfoByMailid.get(sqi.getMailid()).remove(sqi);
+            }
+        }
+    }
+
+    @Override
+    public void setSendingResult(@NotNull QueueInfo qi) {
+        Objects.requireNonNull(qi, "qi");
+
+        synchronized (lock) {
+            QueueInfo uniqueQueueInfo = queueInfoByMailidAndRecipient.get(createSearchKey(qi.getMailid(), qi.getRecipient()));
+
+            if (uniqueQueueInfo != null) {
+                uniqueQueueInfo.setAttempt(System.currentTimeMillis() + AspirinInternal.getConfiguration().getDeliveryAttemptDelay());
+                uniqueQueueInfo.incAttemptCount();
+                uniqueQueueInfo.setState(qi.getState());
+            }
+        }
+    }
+
+    @Override
+    public int size() {
+        return queueInfoByMailid.size();
+    }
 }

--- a/src/test/java/org/masukomi/aspirin/core/DNSJavaTest.java
+++ b/src/test/java/org/masukomi/aspirin/core/DNSJavaTest.java
@@ -5,42 +5,36 @@
  */
 package org.masukomi.aspirin.core;
 
-import java.util.Collection;
-
-import javax.mail.URLName;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.masukomi.aspirin.core.dns.DnsResolver;
+
+import javax.mail.URLName;
+import java.util.Collection;
+
 /**
  * <p>Test of DNS resolving.</p>
  *
  * @author masukomi (masukomi at masukomi dot org)
- *
  */
 public class DNSJavaTest {
-
-	/**
-	 * DNS test with three problematic domains.
-	 */
-	@Test
-	public void testDNSLookup() {
-		System.out.println("Three domains with problematic MX records.");
-
-		System.out.println("testing gmx.net");
-		final Collection<URLName> mxRecords1 = DnsResolver.getMXRecordsForHost("gmx.net");
-		Assert.assertNotNull(mxRecords1);
-		Assert.assertTrue(mxRecords1.size() > 0);
-
-		System.out.println("testing green.ch");
-		final Collection<URLName> mxRecords2 = DnsResolver.getMXRecordsForHost("green.ch");
-		Assert.assertNotNull(mxRecords2);
-		Assert.assertTrue(mxRecords2.size() > 0);
-
-		System.out.println("testing tschannen.cc");
-		final Collection<URLName> mxRecords3 = DnsResolver.getMXRecordsForHost("tschannen.cc");
-		Assert.assertNotNull(mxRecords3);
-		Assert.assertTrue(mxRecords3.size() > 0);
-	}
-
+    /**
+     * DNS test with three problematic domains.
+     */
+    @Test
+    public void testDNSLookup() {
+        System.out.println("Three domains with problematic MX records.");
+        System.out.println("testing gmx.net");
+        Collection<URLName> mxRecords1 = DnsResolver.getMXRecordsForHost("gmx.net");
+        Assert.assertNotNull(mxRecords1);
+        Assert.assertFalse(mxRecords1.isEmpty());
+        System.out.println("testing green.ch");
+        Collection<URLName> mxRecords2 = DnsResolver.getMXRecordsForHost("green.ch");
+        Assert.assertNotNull(mxRecords2);
+        Assert.assertFalse(mxRecords2.isEmpty());
+        System.out.println("testing tschannen.cc");
+        Collection<URLName> mxRecords3 = DnsResolver.getMXRecordsForHost("tschannen.cc");
+        Assert.assertNotNull(mxRecords3);
+        Assert.assertFalse(mxRecords3.isEmpty());
+    }
 }

--- a/src/test/java/org/masukomi/aspirin/core/DefunctGenericObjectPoolTest.java
+++ b/src/test/java/org/masukomi/aspirin/core/DefunctGenericObjectPoolTest.java
@@ -4,16 +4,14 @@ import junit.framework.TestCase;
 
 /**
  * <p>Test of RemoteDelivery object pool in QueueManager.</p>
- *
  */
 public class DefunctGenericObjectPoolTest extends TestCase {
+    public static void main(String[] args) {
+    }
 
-	public static void main(String[] args) {
-	}
-
-	public void testPoolObject() throws Exception {
+    public void testPoolObject() {
 //		DeliveryManager dM = AspirinInternal.getDeliveryManager();
-		
+
 //		
 //		QueManager qm = new QueManager(new MailQue());
 //		ObjectPool qmPool = qm.getRemoteDeliveryObjectPool();
@@ -38,6 +36,6 @@ public class DefunctGenericObjectPoolTest extends TestCase {
 //		qmPool.returnObject(rd3);
 //
 //		qmPool.clear();
-	}
+    }
 
 }

--- a/src/test/java/org/masukomi/aspirin/core/DefunctModuleTest.java
+++ b/src/test/java/org/masukomi/aspirin/core/DefunctModuleTest.java
@@ -1,67 +1,69 @@
 package org.masukomi.aspirin.core;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.lang.management.ManagementFactory;
-import java.util.Properties;
-
-import javax.mail.Address;
-import javax.mail.Session;
-import javax.mail.Message.RecipientType;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
-
+import junit.framework.TestCase;
 import org.masukomi.aspirin.Aspirin;
 import org.masukomi.aspirin.core.config.Configuration;
 import org.masukomi.aspirin.core.store.mail.FileMailStore;
 
-import junit.framework.TestCase;
+import javax.mail.Address;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import javax.management.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.Properties;
 
 public class DefunctModuleTest extends TestCase {
-
-	public void testAspirin(String[] args) throws Exception {
-		// 1. Configure aspirin
-		Configuration config = AspirinInternal.getConfiguration();
-		config.setDeliveryAttemptCount(3);
-		config.setDeliveryAttemptDelay(5);
-		config.setDeliveryDebug(true);
-		config.setDeliveryThreadsActiveMax(3);
-		config.setDeliveryThreadsIdleMax(3);
-		config.setDeliveryTimeout(100000); // 100 seconds
-		config.setEncoding("UTF-8");
-		config.setHostname("localhost");
-		config.setLoggerName("MailService");
-		config.setLoggerPrefix("MailService");
-		config.setPostmasterEmail(null);
-		FileMailStore fms = new FileMailStore();
-		fms.setRootDir(new File("D:\\temp"));
-		fms.setSubDirCount(10);
-		config.setMailStore(fms);
-		
-		MBeanServer mbS = ManagementFactory.getPlatformMBeanServer();
-		mbS.registerMBean(config, new ObjectName("org.masukomi.aspirin:type=Configuration"));
+    public void testAspirin(String[] args) throws MalformedObjectNameException, NotCompliantMBeanException, InstanceAlreadyExistsException, MBeanRegistrationException, IOException, MessagingException {
+        // 1. Configure aspirin
+        Configuration config = AspirinInternal.getConfiguration();
+        config.setDeliveryAttemptCount(3);
+        config.setDeliveryAttemptDelay(5);
+        config.setDeliveryDebug(true);
+        config.setDeliveryThreadsActiveMax(3);
+        config.setDeliveryThreadsIdleMax(3);
+        config.setDeliveryTimeout(100000); // 100 seconds
+        config.setEncoding("UTF-8");
+        config.setHostname("localhost");
+        config.setLoggerName("MailService");
+        config.setLoggerPrefix("MailService");
+        config.setPostmasterEmail(null);
+        FileMailStore fms = new FileMailStore();
+        fms.setRootDir(new File("D:\\temp"));
+        fms.setSubDirCount(10);
+        config.setMailStore(fms);
+        MBeanServer mbS = ManagementFactory.getPlatformMBeanServer();
+        mbS.registerMBean(config, new ObjectName("org.masukomi.aspirin:type=Configuration"));
 
 //		@SuppressWarnings("unused")
 //		Logger logger = Logger.getLogger("MailService");
 //		PropertyConfigurator.configure(args[2]);
 
-		// 2. Start Aspirin and send new message
+        // 2. Start Aspirin and send new message
 //		MailQue mq = new MailQue();
 //		mbS.registerMBean(mq, new ObjectName("org.masukomi.aspirin:type=MailQue"));
-		
-		// 3.A Add test mail watcher
+
+        // 3.A Add test mail watcher
 //		mq.addWatcher(new TestMailWatcher());
 
-		File f = new File(args[0]);
-		Properties props = System.getProperties();
-		for( int i = 0; i < Integer.valueOf(args[1])*2; i+=2 )
-		{
-			MimeMessage mMsg = new MimeMessage(Session.getDefaultInstance(props),new FileInputStream(f));
-			mMsg.addRecipients(RecipientType.TO, new Address[]{(Address)new InternetAddress("test"+i+"@mailinator.com"),(Address)new InternetAddress("test"+(i+1)+"@mailinator.com")});
-			Aspirin.add(mMsg);
-		}
-	}
+        File file = new File(args[0]);
+        Properties props = System.getProperties();
 
+        for (int i = 0; i < Integer.parseInt(args[1]) * 2; i += 2) {
+            try (FileInputStream is = new FileInputStream(file)) {
+                MimeMessage mMsg = new MimeMessage(Session.getDefaultInstance(props), is);
+
+                mMsg.addRecipients(
+                        Message.RecipientType.TO,
+                        new Address[]{new InternetAddress("test" + i + "@mailinator.com"), new InternetAddress("test" + (i + 1) + "@mailinator.com")});
+
+                Aspirin.add(mMsg);
+            }
+        }
+    }
 }

--- a/src/test/java/org/masukomi/aspirin/core/MS.java
+++ b/src/test/java/org/masukomi/aspirin/core/MS.java
@@ -1,48 +1,39 @@
 /**
  * MS.java
- * 
- * 
+ * <p>
+ * <p>
  * Created: Thu Sep 2 18:05:35 2004
- * 
+ *
  * @author <a href="mailto:shiva@int">Shiva Chaudhuri </a>
  * @version 1.0
  */
 package org.masukomi.aspirin.core;
 
+import org.junit.Assert;
+import org.masukomi.aspirin.Aspirin;
+
 import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
-import org.masukomi.aspirin.Aspirin;
-
 public class MS {
-	public MS() {
-
-	}
-
-	public static void main(String[] args) {
-		try {
-			System.out.println("starting");
-			MimeMessage message = AspirinInternal.createNewMimeMessage();
-
-			message.setFrom(new InternetAddress(
-					"jUnit-aspirin-test@masukomi.org"));
-			message.addRecipient(Message.RecipientType.TO, new InternetAddress(
-					"aspirin-test@masukomi.org"));
-			message.setSubject("Aspirin - test to show it doesn't shut down");
-			message.setText("This is the text");
-			Aspirin.add(message);
-			System.out.println("queing mail");
-			Aspirin.shutdown();
-			System.out.println("shutting down");
-
-			
-		} catch (Exception ex) {
-			ex.printStackTrace();
-
-		}
-
-	}
+    public static void main(String[] args) {
+        try {
+            System.out.println("starting");
+            MimeMessage message = AspirinInternal.createNewMimeMessage();
+            message.setFrom(new InternetAddress("jUnit-aspirin-test@masukomi.org"));
+            message.addRecipient(Message.RecipientType.TO, new InternetAddress("aspirin-test@masukomi.org"));
+            message.setSubject("Aspirin - test to show it doesn't shut down");
+            message.setText("This is the text");
+            Aspirin.add(message);
+            System.out.println("queing mail");
+            Aspirin.shutdown();
+            System.out.println("shutting down");
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail();
+        }
+    }
 
 //	/**
 //	 * Flush pending messages and shut down queue. Ideally, a mail queue should

--- a/src/test/java/org/masukomi/aspirin/core/dns/DNSResolverTests.java
+++ b/src/test/java/org/masukomi/aspirin/core/dns/DNSResolverTests.java
@@ -1,33 +1,29 @@
 package org.masukomi.aspirin.core.dns;
 
-import java.util.Collection;
-
-import javax.mail.URLName;
-
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 
+import javax.mail.URLName;
+import java.util.Collection;
+
 public class DNSResolverTests {
-	
-	@Test
-	public void resolveMXRecords() {
-		System.out.println("three problematic domains for MX Record retreival");
+    @Test
+    public void resolveMXRecords() {
+        System.out.println("three problematic domains for MX Record retrieval");
 
-		System.out.println("testing gmx.net");
-		final Collection<URLName> mxRecords1 = DnsResolver.getMXRecordsForHost("gmx.net");
-		Assert.assertNotNull(mxRecords1);
-		Assert.assertTrue(mxRecords1.size() > 0);
+        System.out.println("testing gmx.net");
+        Collection<URLName> mxRecords1 = DnsResolver.getMXRecordsForHost("gmx.net");
+        Assert.assertNotNull(mxRecords1);
+        Assert.assertFalse(mxRecords1.isEmpty());
 
-		System.out.println("testing green.ch");
-		final Collection<URLName> mxRecords2 = DnsResolver.getMXRecordsForHost("green.ch");
-		Assert.assertNotNull(mxRecords2);
-		Assert.assertTrue(mxRecords2.size() > 0);
+        System.out.println("testing green.ch");
+        Collection<URLName> mxRecords2 = DnsResolver.getMXRecordsForHost("green.ch");
+        Assert.assertNotNull(mxRecords2);
+        Assert.assertFalse(mxRecords2.isEmpty());
 
-		System.out.println("testing tschannen.cc");
-		final Collection<URLName> mxRecords3 = DnsResolver.getMXRecordsForHost("tschannen.cc");
-		Assert.assertNotNull(mxRecords3);
-		Assert.assertTrue(mxRecords3.size() > 0);
-	}
-
+        System.out.println("testing tschannen.cc");
+        Collection<URLName> mxRecords3 = DnsResolver.getMXRecordsForHost("tschannen.cc");
+        Assert.assertNotNull(mxRecords3);
+        Assert.assertFalse(mxRecords3.isEmpty());
+    }
 }

--- a/src/test/resources/Configuration.xml
+++ b/src/test/resources/Configuration.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <preferences EXTERNAL_XML_VERSION="1.0">
-  <root type="file">
-    <map />
-    <node name="root">
-      <map>
-        <entry key="maxAttempts" value="1" group="" />
-        <entry key="postmaster" value="root@localhost" group="" />
-        <entry key="deliveryThreads" value="1" group="" />
-        <entry key="retryInterval" value="60000" group="" />
-      </map>
-    </node>
-  </root>
+    <root type="file">
+        <map/>
+        <node name="root">
+            <map>
+                <entry key="maxAttempts" value="1" group=""/>
+                <entry key="postmaster" value="root@localhost" group=""/>
+                <entry key="deliveryThreads" value="1" group=""/>
+                <entry key="retryInterval" value="60000" group=""/>
+            </map>
+        </node>
+    </root>
 </preferences>
-

--- a/src/test/resources/Logs.xml
+++ b/src/test/resources/Logs.xml
@@ -1,45 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <preferences EXTERNAL_XML_VERSION="1.0">
-  <root type="system">
-    <map />
-    <node name="org">
-      <map />
-      <node name="masukomi">
-        <map />
-        <node name="tools">
-          <map />
-          <node name="logging">
-            <map />
-              <node name="Logs">
-	            <map>
-	              <entry key="entriesLogFile" value="" />
-	              <!-- enter the path to a log file as the value if you wish to have one -->
-	              <entry key="logFileRequired" value="false" />
-	              <!-- if this is true and it can't open the log file specified in entriesLogFile
-	              	it will barf -->
-	              <entry key="entriesToSystemOut" value="false" />
-	              <!--
-	              	would you like nicely formatted log messages printed to standard out?
-	              	-->
-	              <entry key="entryLogThreshold" value="DEBUG" />
-	              <!-- options for entryLogThreshold are:
-	              	DEBUG
-	              	INFO
-	              	WARN
-	              	ERROR
-	              	-->
-	              <entry key="entriesWarningLevel" value="-1" />
-	              <!-- leave the following entries. they aren't currently used in Aspirin-->
-	              <entry key="webmaster" value="masukomi@masukomi.org" />
-	              <entry key="smtpServer" value="localhost" />
-	              <entry key="FATAL_htmlColor" value="#ff4533" />
-                  <entry key="ERROR_htmlColor" value="#ffa018" />
-                  <entry key="WARN_htmlColor" value="#ffce0b" />
-	            </map>
-              </node>
-          </node>
+    <root type="system">
+        <map/>
+        <node name="org">
+            <map/>
+            <node name="masukomi">
+                <map/>
+                <node name="tools">
+                    <map/>
+                    <node name="logging">
+                        <map/>
+                        <node name="Logs">
+                            <map>
+                                <entry key="entriesLogFile" value=""/>
+                                <!-- enter the path to a log file as the value if you wish to have one -->
+                                <entry key="logFileRequired" value="false"/>
+                                <!-- if this is true and it can't open the log file specified in entriesLogFile
+                                    it will barf -->
+                                <entry key="entriesToSystemOut" value="false"/>
+                                <!--
+                                    would you like nicely formatted log messages printed to standard out?
+                                    -->
+                                <entry key="entryLogThreshold" value="DEBUG"/>
+                                <!-- options for entryLogThreshold are:
+                                    DEBUG
+                                    INFO
+                                    WARN
+                                    ERROR
+                                    -->
+                                <entry key="entriesWarningLevel" value="-1"/>
+                                <!-- leave the following entries. they aren't currently used in Aspirin-->
+                                <entry key="webmaster" value="masukomi@masukomi.org"/>
+                                <entry key="smtpServer" value="localhost"/>
+                                <entry key="FATAL_htmlColor" value="#ff4533"/>
+                                <entry key="ERROR_htmlColor" value="#ffa018"/>
+                                <entry key="WARN_htmlColor" value="#ffce0b"/>
+                            </map>
+                        </node>
+                    </node>
+                </node>
+            </node>
         </node>
-      </node>
-    </node>
-  </root>
+    </root>
 </preferences>

--- a/www/configuration.html
+++ b/www/configuration.html
@@ -1,40 +1,42 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
-  <meta content="text/html; charset=ISO-8859-1"
- http-equiv="content-type">
-  <title>Aspirin - embeddable java smtp server</title>
+    <meta content="text/html; charset=ISO-8859-1"
+          http-equiv="content-type">
+    <title>Aspirin - embeddable java smtp server</title>
 </head>
 <body>
 <span style="font-weight: bold;"><img alt="An Aspirin..."
- src="pill.gif" style="width: 100px; height: 100px;"><big>Aspirin,
+                                      src="pill.gif" style="width: 100px; height: 100px;"><big>Aspirin,
 because sending mail shouldn't be a headache. </big><br>
 <br>
 Configuring Aspirin</span><br>
 <div style="margin-left: 40px;">
-<p>Aspirin can be configured three ways. You can set system preferences before it loads. 
-	You can call the setters in org.masukomi.aspirin.code.Configuration. Or, you can do nothing and 
-	accept the defaul settings.  </p>
-<p><b>Setting System Preferences</b><br/>
-	Aspirin uses the following system preferences:
-	</p>
-	<ul>
-		<li>aspirinRetryInterval - the number of milliseconds before a failed e-mail is retried. Default is 5 minutes</li>
-		<li>aspirinDeliverThreads - the number of delivery threads in the thread pool. Default is 3.</li>
-		<li>aspirinPostmaster - the e-mail address of the person to send bounce messages to.</li>
-		<li>aspirinMaxAttempts - the maximum number of times it will try and send a message if it has problems.</li>
-	</ul>
-<p><b>Configuring via setter methods</b><br />
-	See the Javadocs in <tt>org.masukomi.aspirin.core.config.Configuration</tt>for details on this method.  </p>
-<p><b>Configuring via doing nothing</b><br />
-	See above for the default settings. </p>
-<p><b>Configuring Aspirin's Logging</span><br>
+    <p>Aspirin can be configured three ways. You can set system preferences before it loads.
+        You can call the setters in org.masukomi.aspirin.code.Configuration. Or, you can do nothing and
+        accept the defaul settings. </p>
+    <p><b>Setting System Preferences</b><br/>
+        Aspirin uses the following system preferences:
+    </p>
+    <ul>
+        <li>aspirinRetryInterval - the number of milliseconds before a failed e-mail is retried. Default is 5 minutes
+        </li>
+        <li>aspirinDeliverThreads - the number of delivery threads in the thread pool. Default is 3.</li>
+        <li>aspirinPostmaster - the e-mail address of the person to send bounce messages to.</li>
+        <li>aspirinMaxAttempts - the maximum number of times it will try and send a message if it has problems.</li>
+    </ul>
+    <p><b>Configuring via setter methods</b><br/>
+        See the Javadocs in <tt>org.masukomi.aspirin.core.config.Configuration</tt>for details on this method. </p>
+    <p><b>Configuring via doing nothing</b><br/>
+        See above for the default settings. </p>
+    <p><b>Configuring Aspirin's Logging</b><br>
 
-Aspirin uses <a href="http://jakarta.apache.org/commons/logging/">Commons Logging</a>. Please see the "Configuration" section of the 
-Commons Logging <a href="http://jakarta.apache.org/commons/logging/guide.html">User Guide</a> for details. 
-</p>
-<p><b>Classpath Requirements</b><br />
-	mail.jar and activation.jar must be added to the classpath. </p>
+        Aspirin uses <a href="http://jakarta.apache.org/commons/logging/">Commons Logging</a>. Please see the
+        "Configuration" section of the
+        Commons Logging <a href="http://jakarta.apache.org/commons/logging/guide.html">User Guide</a> for details.
+    </p>
+    <p><b>Classpath Requirements</b><br/>
+        mail.jar and activation.jar must be added to the classpath. </p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
- Reformat everything according the standard Java code style, 
- improve thread-safety,
- change Java target to 1.8, 
- more use functional style (Stream API, comparators, add `@FunctionalInterface` to handlers), 
- add nullability annotations for better static analysis and Kotlin interop, 
- widen many types in the code (i.e. `Collection<T>` -> `Iterable<T>`), 
- make `Properties` access type-safe, update exception handling and checking (remove redundant throw clauses and make handlers less wide), 
- optimize imports, 
- remove default-valued initializers (0, `false`, `null`), 
- add null checks with `java.util.Objects`, 
- make `final` many private fields